### PR TITLE
Backport edx-enterprise enrollments API changes from master to 3.42.5

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,11 @@ Change Log
 Unreleased
 ----------
 * nothing
+[3.61.5]
+--------
+feat: allow enrollment api admin to see all enrollments
+feat: extend EnterpriseCourseEnrollmentReadOnlySerializer
+
 
 [3.42.5]
 ---------

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -320,8 +320,20 @@ class EnterpriseCourseEnrollmentReadOnlySerializer(serializers.ModelSerializer):
     class Meta:
         model = models.EnterpriseCourseEnrollment
         fields = (
-            'enterprise_customer_user', 'course_id'
+            'enterprise_customer_user',
+            'course_id',
+            'enrollment_date',
+            'enrollment_track',
+            'user_email',
+            'course_start',
+            'course_end',
         )
+
+    enrollment_track = serializers.CharField()
+    enrollment_date = serializers.DateTimeField()
+    user_email = serializers.EmailField()
+    course_start = serializers.DateTimeField()
+    course_end = serializers.DateTimeField()
 
 
 class EnterpriseCourseEnrollmentWriteSerializer(serializers.ModelSerializer):

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -41,6 +41,7 @@ from django.utils.translation import gettext as _
 
 from enterprise import models
 from enterprise.api.filters import (
+    EnterpriseCourseEnrollmentFilterBackend,
     EnterpriseCustomerInviteKeyFilterBackend,
     EnterpriseCustomerUserFilterBackend,
     EnterpriseLinkedUserFilterBackend,
@@ -457,6 +458,7 @@ class EnterpriseCourseEnrollmentViewSet(EnterpriseReadWriteModelViewSet):
     """
 
     queryset = models.EnterpriseCourseEnrollment.objects.all()
+    filter_backends = (filters.OrderingFilter, DjangoFilterBackend, EnterpriseCourseEnrollmentFilterBackend)
 
     USER_ID_FILTER = 'enterprise_customer_user__user_id'
     FIELDS = (

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -79,6 +79,11 @@ try:
 except ImportError:
     CourseEnrollment = None
 
+try:
+    from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+except ImportError:
+    CourseOverview = None
+
 LOGGER = getLogger(__name__)
 User = auth.get_user_model()
 mark_safe_lazy = lazy(mark_safe, str)
@@ -1660,9 +1665,44 @@ class EnterpriseCourseEnrollmentManager(models.Manager):
         """
         Override to return only those enrollment records for which learner is linked to an enterprise.
         """
+
         return super().get_queryset().select_related('enterprise_customer_user').filter(
             enterprise_customer_user__linked=True
+        ).annotate(**self._get_additional_data_annotations())
+
+    def _get_additional_data_annotations(self):
+        """
+        Return annotations with additional data for the queryset.
+        Additional fields are None in the test environment, where platform models are not available.
+        """
+
+        if not CourseEnrollment or not CourseOverview:
+            return {
+                'enrollment_track': models.Value(None, output_field=models.CharField()),
+                'enrollment_date': models.Value(None, output_field=models.DateTimeField()),
+                'user_email': models.Value(None, output_field=models.EmailField()),
+                'course_start': models.Value(None, output_field=models.DateTimeField()),
+                'course_end': models.Value(None, output_field=models.DateTimeField()),
+            }
+
+        enrollment_subquery = CourseEnrollment.objects.filter(
+            user=models.OuterRef('enterprise_customer_user__user_id'),
+            course_id=models.OuterRef('course_id'),
         )
+        user_subquery = auth.get_user_model().objects.filter(
+            id=models.OuterRef('enterprise_customer_user__user_id'),
+        ).values('email')[:1]
+        course_subquery = CourseOverview.objects.filter(
+            id=models.OuterRef('course_id'),
+        )
+
+        return {
+            'enrollment_track': models.Subquery(enrollment_subquery.values('mode')[:1]),
+            'enrollment_date': models.Subquery(enrollment_subquery.values('created')[:1]),
+            'user_email': models.Subquery(user_subquery),
+            'course_start': models.Subquery(course_subquery.values('start')[:1]),
+            'course_end': models.Subquery(course_subquery.values('end')[:1]),
+        }
 
 
 class EnterpriseCourseEnrollment(TimeStampedModel):

--- a/test_utils/factories.py
+++ b/test_utils/factories.py
@@ -25,6 +25,8 @@ from enterprise.models import (
     EnterpriseCustomerInviteKey,
     EnterpriseCustomerReportingConfiguration,
     EnterpriseCustomerUser,
+    EnterpriseFeatureRole,
+    EnterpriseFeatureUserRoleAssignment,
     LicensedEnterpriseCourseEnrollment,
     PendingEnrollment,
     PendingEnterpriseCustomerAdminUser,
@@ -279,6 +281,41 @@ class UserFactory(factory.django.DjangoModelFactory):
     is_staff = False
     is_active = False
     date_joined = factory.LazyAttribute(lambda x: FAKER.date_time_this_year(tzinfo=timezone.utc))
+
+
+class EnterpriseFeatureRoleFactory(factory.django.DjangoModelFactory):
+    """
+    EnterpriseFeatureRole factory.
+
+    Creates an instance of EnterpriseFeatureRole with minimal boilerplate.
+    """
+
+    class Meta:
+        """
+        Meta for EnterpriseFeatureRoleFactory.
+        """
+
+        model = EnterpriseFeatureRole
+
+    name = factory.LazyAttribute(lambda x: FAKER.word())
+
+
+class EnterpriseFeatureUserRoleAssignmentFactory(factory.django.DjangoModelFactory):
+    """
+    EnterpriseFeatureUserRoleAssignment factory.
+
+    Creates an instance of EnterpriseFeatureUserRoleAssignment with minimal boilerplate.
+    """
+
+    class Meta:
+        """
+        Meta for EnterpriseFeatureUserRoleAssignmentFactory.
+        """
+
+        model = EnterpriseFeatureUserRoleAssignment
+
+    role = factory.SubFactory(EnterpriseFeatureRoleFactory)
+    user = factory.SubFactory(UserFactory)
 
 
 class AnonymousUserFactory(factory.Factory):

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -1223,6 +1223,11 @@ class TestEnterpriseCustomerViewSet(BaseTestEnterpriseAPIViews):
             [{
                 'enterprise_customer_user': 1,
                 'course_id': 'course-v1:edX+DemoX+DemoCourse',
+                'enrollment_date': None,
+                'enrollment_track': None,
+                'user_email': None,
+                'course_start': None,
+                'course_end': None,
             }],
         ),
         (


### PR DESCRIPTION
## Description

This is a backport of https://github.com/openedx/edx-enterprise/pull/1714 to version `3.42.5` (used by Nutmeg).

A new branch named opencraft-release/nutmeg.master has been created to keep the code-drift.
 