### PR TITLE
Backport enterprise course enrollments api implementation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,9 @@ Unreleased
 ----------
 * nothing
 
+[3.42.8]
+feat: add additional fields to EnterpriseCourseEnrollmentViewSet
+
 [3.42.7]
 --------
 feat: allow enrollment to invite-only courses via manage learners admin page

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.42.7"
+__version__ = "3.42.8"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -316,12 +316,24 @@ class EnterpriseCourseEnrollmentReadOnlySerializer(serializers.ModelSerializer):
     """
     Serializer for EnterpriseCourseEnrollment model.
     """
+    class Meta:
+        model = models.EnterpriseCourseEnrollment
+        fields = (
+            'enterprise_customer_user', 'course_id', 'created',
+        )
+
+
+class EnterpriseCourseEnrollmentWithAdditionalFieldsReadOnlySerializer(EnterpriseCourseEnrollmentReadOnlySerializer):
+    """
+    Serializer for EnterpriseCourseEnrollment model with additional fields.
+    """
 
     class Meta:
         model = models.EnterpriseCourseEnrollment
         fields = (
             'enterprise_customer_user',
             'course_id',
+            'created',
             'enrollment_date',
             'enrollment_track',
             'user_email',

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -457,7 +457,7 @@ class EnterpriseCourseEnrollmentViewSet(EnterpriseReadWriteModelViewSet):
     API views for the ``enterprise-course-enrollment`` API endpoint.
     """
 
-    queryset = models.EnterpriseCourseEnrollment.objects.all()
+    queryset = models.EnterpriseCourseEnrollment.with_additional_fields.all()
     filter_backends = (filters.OrderingFilter, DjangoFilterBackend, EnterpriseCourseEnrollmentFilterBackend)
 
     USER_ID_FILTER = 'enterprise_customer_user__user_id'
@@ -472,7 +472,7 @@ class EnterpriseCourseEnrollmentViewSet(EnterpriseReadWriteModelViewSet):
         Use a special serializer for any requests that aren't read-only.
         """
         if self.request.method in ('GET',):
-            return serializers.EnterpriseCourseEnrollmentReadOnlySerializer
+            return serializers.EnterpriseCourseEnrollmentWithAdditionalFieldsReadOnlySerializer
         return serializers.EnterpriseCourseEnrollmentWriteSerializer
 
 

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -1683,6 +1683,21 @@ class EnterpriseCourseEnrollmentManager(models.Manager):
 
         return super().get_queryset().select_related('enterprise_customer_user').filter(
             enterprise_customer_user__linked=True
+        )
+
+
+class EnterpriseCourseEnrollmentWithAdditionalFieldsManager(models.Manager):
+    """
+    Model manager for `EnterpriseCourseEnrollment`.
+    """
+
+    def get_queryset(self):
+        """
+        Override to return only those enrollment records for which learner is linked to an enterprise.
+        """
+
+        return super().get_queryset().select_related('enterprise_customer_user').filter(
+            enterprise_customer_user__linked=True
         ).annotate(**self._get_additional_data_annotations())
 
     def _get_additional_data_annotations(self):
@@ -1739,6 +1754,7 @@ class EnterpriseCourseEnrollment(TimeStampedModel):
     """
 
     objects = EnterpriseCourseEnrollmentManager()
+    with_additional_fields = EnterpriseCourseEnrollmentWithAdditionalFieldsManager()
 
     class Meta:
         unique_together = (('enterprise_customer_user', 'course_id',),)

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -1220,10 +1220,12 @@ class TestEnterpriseCustomerViewSet(BaseTestEnterpriseAPIViews):
             [{
                 'enterprise_customer_user__id': 1,
                 'course_id': 'course-v1:edX+DemoX+DemoCourse',
+                'created': '2021-10-20T19:01:31Z',
             }],
             [{
                 'enterprise_customer_user': 1,
                 'course_id': 'course-v1:edX+DemoX+DemoCourse',
+                'created': '2021-10-20T19:01:31Z',
                 'enrollment_date': None,
                 'enrollment_track': None,
                 'user_email': None,


### PR DESCRIPTION
## Description

This is a backport to match some of the enhancements to edx-enterprise in https://github.com/openedx/edx-enterprise/pull/1714/ as they were out of sync and had a slightly different implementation to that upstream PR.

## Testing instructions

Follow the same testing instructions from https://github.com/openedx/edx-enterprise/issues/1714/ , but since this PR only updates the implementation of the additional fields for the `EnterpriseCourseEnrollmentViewSet`, we are only concerned that the response of the `GET /enterprise/api/v1/enterprise-course-enrollment/` endpoint returns the additional fields with no errors, and includes the backported `created` field. Example response:

```json
{
    "next": null,
    "previous": null,
    "count": 3,
    "num_pages": 1,
    "current_page": 1,
    "start": 0,
    "results": [
        {
            "enterprise_customer_user": 10,
            "course_id": "course-v1:edX+DemoX+Demo_Course",
            "created": "2023-06-15T08:12:56.901855Z",
            "enrollment_date": "2023-06-15T08:12:05.294402Z",
            "enrollment_track": "audit",
            "user_email": "[test-enterprise_learner_2@example.com](mailto:test-enterprise_learner_2@example.com)",
            "course_start": "2013-02-05T05:00:00Z",
            "course_end": null
        },
        {
            "enterprise_customer_user": 8,
            "course_id": "course-v1:edX+DemoX+Demo_Course",
            "created": "2023-06-15T08:17:30.665560Z",
            "enrollment_date": "2023-06-15T08:17:30.527914Z",
            "enrollment_track": "audit",
            "user_email": "[enterprise_worker@example.com](mailto:enterprise_worker@example.com)",
            "course_start": "2013-02-05T05:00:00Z",
            "course_end": null
        },
        {
            "enterprise_customer_user": 9,
            "course_id": "course-v1:edX+DemoX+Demo_Course",
            "created": "2023-06-15T08:17:31.337671Z",
            "enrollment_date": "2023-06-15T08:17:31.225235Z",
            "enrollment_track": "audit",
            "user_email": "[test-enterprise_learner_1@example.com](mailto:test-enterprise_learner_1@example.com)",
            "course_start": "2013-02-05T05:00:00Z",
            "course_end": null
        }
    ]
}
```
