### PR TITLE
feat: cherry-pick edx-enterprise customizations to Palm [BB-7878]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [master]
   pull_request:
-    branches: [master]
 
 concurrency:
   group: ci-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/mysql8-migrations.yml
+++ b/.github/workflows/mysql8-migrations.yml
@@ -45,6 +45,10 @@ jobs:
         key: ${{ runner.os }}-pip-${{ hashFiles('requirements/pip_tools.txt') }}
         restore-keys: ${{ runner.os }}-pip-
 
+    - name: Downgrade pip to work around https://github.com/mitsuhiko/rye/issues/368
+      run: |
+        pip install --upgrade pip==23.1
+
     - name: Ubuntu and sql Versions
       run: |
         lsb_release -a

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,11 @@ Unreleased
 ----------
 * Nothing
 
+[3.61.12]
+---------
+This version is based on v3.61.11 and contains some backports needed to OpenCraft's clients. There is no "official" v3.61.12.
+See this PR for more details: https://github.com/open-craft/edx-enterprise/pull/10
+
 [3.61.11]
 ---------
 feat: include owners and longer descriptions for degreed2 content metadata transmissions

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.61.11"
+__version__ = "3.61.12"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/enterprise/admin/forms.py
+++ b/enterprise/admin/forms.py
@@ -68,6 +68,11 @@ class ManageLearnersForm(forms.Form):
         label=_("Enroll these learners in this course"), required=False,
         help_text=_("To enroll learners in a course, enter a course ID."),
     )
+    force_enrollment = forms.BooleanField(
+        label=_("Force Enrollment"),
+        help_text=_("The selected course is 'Invite Only'. Only staff can enroll learners to this course."),
+        required=False,
+    )
     course_mode = forms.ChoiceField(
         label=_("Course enrollment track"), required=False,
         choices=BLANK_CHOICE_DASH + [
@@ -130,6 +135,7 @@ class ManageLearnersForm(forms.Form):
         REASON = "reason"
         SALES_FORCE_ID = "sales_force_id"
         DISCOUNT = "discount"
+        FORCE_ENROLLMENT = "force_enrollment"
 
     class CsvColumns:
         """

--- a/enterprise/admin/forms.py
+++ b/enterprise/admin/forms.py
@@ -400,6 +400,7 @@ class EnterpriseCustomerAdminForm(forms.ModelForm):
             "enable_audit_data_reporting",
             "replace_sensitive_sso_username",
             "hide_course_original_price",
+            "hide_course_price_when_zero",
             "enable_portal_code_management_screen",
             "enable_portal_subscription_management_screen",
             "enable_learner_portal",

--- a/enterprise/admin/forms.py
+++ b/enterprise/admin/forms.py
@@ -401,6 +401,7 @@ class EnterpriseCustomerAdminForm(forms.ModelForm):
             "replace_sensitive_sso_username",
             "hide_course_original_price",
             "hide_course_price_when_zero",
+            "allow_enrollment_in_invite_only_courses",
             "enable_portal_code_management_screen",
             "enable_portal_subscription_management_screen",
             "enable_learner_portal",

--- a/enterprise/admin/views.py
+++ b/enterprise/admin/views.py
@@ -676,7 +676,8 @@ class EnterpriseCustomerManageLearnersView(BaseEnterpriseCustomerView):
             notify=True,
             enrollment_reason=None,
             sales_force_id=None,
-            discount=0.0
+            discount=0.0,
+            force_enrollment=False,
     ):
         """
         Enroll the users with the given email addresses to the course.
@@ -689,6 +690,7 @@ class EnterpriseCustomerManageLearnersView(BaseEnterpriseCustomerView):
             mode: The enrollment mode the users will be enrolled in the course with
             course_id: The ID of the course in which we want to enroll
             notify: Whether to notify (by email) the users that have been enrolled
+            force_enrollment: Force enrollment into "Invite Only" courses
         """
         pending_messages = []
         paid_modes = ['verified', 'professional']
@@ -702,6 +704,7 @@ class EnterpriseCustomerManageLearnersView(BaseEnterpriseCustomerView):
             enrollment_reason=enrollment_reason,
             discount=discount,
             sales_force_id=sales_force_id,
+            force_enrollment=force_enrollment,
         )
         all_successes = succeeded + pending
         if notify:
@@ -818,6 +821,7 @@ class EnterpriseCustomerManageLearnersView(BaseEnterpriseCustomerView):
             sales_force_id = manage_learners_form.cleaned_data.get(ManageLearnersForm.Fields.SALES_FORCE_ID)
             course_mode = manage_learners_form.cleaned_data.get(ManageLearnersForm.Fields.COURSE_MODE)
             course_id = None
+            force_enrollment = manage_learners_form.cleaned_data.get(ManageLearnersForm.Fields.FORCE_ENROLLMENT)
 
             if not course_id_with_emails:
                 course_details = manage_learners_form.cleaned_data.get(ManageLearnersForm.Fields.COURSE) or {}
@@ -832,7 +836,8 @@ class EnterpriseCustomerManageLearnersView(BaseEnterpriseCustomerView):
                         notify=notify,
                         enrollment_reason=manual_enrollment_reason,
                         sales_force_id=sales_force_id,
-                        discount=discount
+                        discount=discount,
+                        force_enrollment=force_enrollment,
                     )
             else:
                 for course_id, emails in course_id_with_emails.items():
@@ -847,7 +852,8 @@ class EnterpriseCustomerManageLearnersView(BaseEnterpriseCustomerView):
                             notify=notify,
                             enrollment_reason=manual_enrollment_reason,
                             sales_force_id=sales_force_id,
-                            discount=discount
+                            discount=discount,
+                            force_enrollment=force_enrollment,
                         )
 
             # Redirect to GET if everything went smooth.

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -325,8 +325,33 @@ class EnterpriseCourseEnrollmentReadOnlySerializer(serializers.ModelSerializer):
     class Meta:
         model = models.EnterpriseCourseEnrollment
         fields = (
-            'enterprise_customer_user', 'course_id'
+            'enterprise_customer_user', 'course_id', 'created'
         )
+
+
+class EnterpriseCourseEnrollmentWithAdditionalFieldsReadOnlySerializer(EnterpriseCourseEnrollmentReadOnlySerializer):
+    """
+    Serializer for EnterpriseCourseEnrollment model with additional fields.
+    """
+
+    class Meta:
+        model = models.EnterpriseCourseEnrollment
+        fields = (
+            'enterprise_customer_user',
+            'course_id',
+            'created',
+            'enrollment_date',
+            'enrollment_track',
+            'user_email',
+            'course_start',
+            'course_end',
+        )
+
+    enrollment_track = serializers.CharField()
+    enrollment_date = serializers.DateTimeField()
+    user_email = serializers.EmailField()
+    course_start = serializers.DateTimeField()
+    course_end = serializers.DateTimeField()
 
 
 class EnterpriseCourseEnrollmentWriteSerializer(serializers.ModelSerializer):

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -46,6 +46,7 @@ from django.utils.translation import gettext as _
 
 from enterprise import models
 from enterprise.api.filters import (
+    EnterpriseCourseEnrollmentFilterBackend,
     EnterpriseCustomerInviteKeyFilterBackend,
     EnterpriseCustomerUserFilterBackend,
     EnterpriseLinkedUserFilterBackend,
@@ -530,7 +531,8 @@ class EnterpriseCourseEnrollmentViewSet(EnterpriseReadWriteModelViewSet):
     API views for the ``enterprise-course-enrollment`` API endpoint.
     """
 
-    queryset = models.EnterpriseCourseEnrollment.objects.all()
+    queryset = models.EnterpriseCourseEnrollment.with_additional_fields.all()
+    filter_backends = (filters.OrderingFilter, DjangoFilterBackend, EnterpriseCourseEnrollmentFilterBackend)
 
     USER_ID_FILTER = 'enterprise_customer_user__user_id'
     FIELDS = (
@@ -544,7 +546,7 @@ class EnterpriseCourseEnrollmentViewSet(EnterpriseReadWriteModelViewSet):
         Use a special serializer for any requests that aren't read-only.
         """
         if self.request.method in ('GET',):
-            return serializers.EnterpriseCourseEnrollmentReadOnlySerializer
+            return serializers.EnterpriseCourseEnrollmentWithAdditionalFieldsReadOnlySerializer
         return serializers.EnterpriseCourseEnrollmentWriteSerializer
 
 

--- a/enterprise/api_client/lms.py
+++ b/enterprise/api_client/lms.py
@@ -128,7 +128,15 @@ class EnrollmentApiClient(BackendServiceAPIClient):
         course_modes = self.get_course_modes(course_run_id)
         return any(course_mode for course_mode in course_modes if course_mode['slug'] == mode)
 
-    def enroll_user_in_course(self, username, course_id, mode, cohort=None, enterprise_uuid=None):
+    def enroll_user_in_course(
+        self,
+        username,
+        course_id,
+        mode,
+        cohort=None,
+        enterprise_uuid=None,
+        force_enrollment=False,
+    ):
         """
         Call the enrollment API to enroll the user in the course specified by course_id.
 
@@ -138,6 +146,7 @@ class EnrollmentApiClient(BackendServiceAPIClient):
             mode (str): The enrollment mode which should be used for the enrollment
             cohort (str): Add the user to this named cohort
             enterprise_uuid (str): Add course enterprise uuid
+            force_enrollment (bool): Force the enrollment even if course is Invite Only
 
         Returns:
             dict: A dictionary containing details of the enrollment, including course details, mode, username, etc.
@@ -152,7 +161,8 @@ class EnrollmentApiClient(BackendServiceAPIClient):
                 'is_active': True,
                 'mode': mode,
                 'cohort': cohort,
-                'enterprise_uuid': str(enterprise_uuid)
+                'enterprise_uuid': str(enterprise_uuid),
+                'force_enrollment': force_enrollment,
             }
         )
         response.raise_for_status()

--- a/enterprise/migrations/0171_adds_hide_course_price_when_zero_to_enterprisecustomer.py
+++ b/enterprise/migrations/0171_adds_hide_course_price_when_zero_to_enterprisecustomer.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('enterprise', '0170_auto_20230301_1627'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='enterprisecustomer',
+            name='hide_course_price_when_zero',
+            field=models.BooleanField(default=False, help_text='Specify whether course cost should be hidden in the landing page when the final price is zero.'),
+        ),
+        migrations.AddField(
+            model_name='historicalenterprisecustomer',
+            name='hide_course_price_when_zero',
+            field=models.BooleanField(default=False, help_text='Specify whether course cost should be hidden in the landing page when the final price is zero.'),
+        ),
+    ]

--- a/enterprise/migrations/0172_adds_allow_enrollment_in_invite_only_courses_flag.py
+++ b/enterprise/migrations/0172_adds_allow_enrollment_in_invite_only_courses_flag.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('enterprise', '0171_adds_hide_course_price_when_zero_to_enterprisecustomer'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='enterprisecustomer',
+            name='allow_enrollment_in_invite_only_courses',
+            field=models.BooleanField(default=False, help_text="Specifies if learners are allowed to enroll into courses marked as 'invitation-only', when they attempt to enroll from the landing page."),
+        ),
+        migrations.AddField(
+            model_name='historicalenterprisecustomer',
+            name='allow_enrollment_in_invite_only_courses',
+            field=models.BooleanField(default=False, help_text="Specifies if learners are allowed to enroll into courses marked as 'invitation-only', when they attempt to enroll from the landing page."),
+        ),
+    ]

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -416,6 +416,14 @@ class EnterpriseCustomer(TimeStampedModel):
         help_text=_("Specify whether course cost should be hidden in the landing page when the final price is zero.")
     )
 
+    allow_enrollment_in_invite_only_courses = models.BooleanField(
+        default=False,
+        help_text=_(
+            "Specifies if learners are allowed to enroll into courses marked as 'invitation-only', "
+            "when they attempt to enroll from the landing page."
+        )
+    )
+
     @property
     def enterprise_customer_identity_provider(self):
         """

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -411,6 +411,11 @@ class EnterpriseCustomer(TimeStampedModel):
         help_text=_("The email address where learner's reply to enterprise emails will be delivered.")
     )
 
+    hide_course_price_when_zero = models.BooleanField(
+        default=False,
+        help_text=_("Specify whether course cost should be hidden in the landing page when the final price is zero.")
+    )
+
     @property
     def enterprise_customer_identity_provider(self):
         """

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -78,9 +78,10 @@ from enterprise.validators import (
 )
 
 try:
-    from common.djangoapps.student.models import CourseEnrollment
+    from common.djangoapps.student.models import CourseEnrollment, CourseEnrollmentAllowed
 except ImportError:
     CourseEnrollment = None
+    CourseEnrollmentAllowed = None
 
 try:
     from common.djangoapps.entitlements.models import CourseEntitlement
@@ -672,7 +673,21 @@ class EnterpriseCustomer(TimeStampedModel):
             license_uuid = None
 
         new_enrollments = {}
+        enrollment_api_client = EnrollmentApiClient()
+
         for course_id in course_ids:
+            # Check if the course is "Invite Only" and add CEA if it is.
+            course_details = enrollment_api_client.get_course_details(course_id)
+
+            if course_details["invite_only"]:
+                if not CourseEnrollmentAllowed:
+                    raise NotConnectedToOpenEdX()
+
+                CourseEnrollmentAllowed.objects.update_or_create(
+                    email=email,
+                    course_id=course_id
+                )
+
             __, created = PendingEnrollment.objects.update_or_create(
                 user=pending_ecu,
                 course_id=course_id,

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -87,6 +87,11 @@ try:
 except ImportError:
     CourseEntitlement = None
 
+try:
+    from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+except ImportError:
+    CourseOverview = None
+
 LOGGER = getLogger(__name__)
 User = auth.get_user_model()
 mark_safe_lazy = lazy(mark_safe, str)
@@ -1781,9 +1786,59 @@ class EnterpriseCourseEnrollmentManager(models.Manager):
         """
         Override to return only those enrollment records for which learner is linked to an enterprise.
         """
+
         return super().get_queryset().select_related('enterprise_customer_user').filter(
             enterprise_customer_user__linked=True
         )
+
+
+class EnterpriseCourseEnrollmentWithAdditionalFieldsManager(models.Manager):
+    """
+    Model manager for `EnterpriseCourseEnrollment`.
+    """
+
+    def get_queryset(self):
+        """
+        Override to return only those enrollment records for which learner is linked to an enterprise.
+        """
+
+        return super().get_queryset().select_related('enterprise_customer_user').filter(
+            enterprise_customer_user__linked=True
+        ).annotate(**self._get_additional_data_annotations())
+
+    def _get_additional_data_annotations(self):
+        """
+        Return annotations with additional data for the queryset.
+        Additional fields are None in the test environment, where platform models are not available.
+        """
+
+        if not CourseEnrollment or not CourseOverview:
+            return {
+                'enrollment_track': models.Value(None, output_field=models.CharField()),
+                'enrollment_date': models.Value(None, output_field=models.DateTimeField()),
+                'user_email': models.Value(None, output_field=models.EmailField()),
+                'course_start': models.Value(None, output_field=models.DateTimeField()),
+                'course_end': models.Value(None, output_field=models.DateTimeField()),
+            }
+
+        enrollment_subquery = CourseEnrollment.objects.filter(
+            user=models.OuterRef('enterprise_customer_user__user_id'),
+            course_id=models.OuterRef('course_id'),
+        )
+        user_subquery = auth.get_user_model().objects.filter(
+            id=models.OuterRef('enterprise_customer_user__user_id'),
+        ).values('email')[:1]
+        course_subquery = CourseOverview.objects.filter(
+            id=models.OuterRef('course_id'),
+        )
+
+        return {
+            'enrollment_track': models.Subquery(enrollment_subquery.values('mode')[:1]),
+            'enrollment_date': models.Subquery(enrollment_subquery.values('created')[:1]),
+            'user_email': models.Subquery(user_subquery),
+            'course_start': models.Subquery(course_subquery.values('start')[:1]),
+            'course_end': models.Subquery(course_subquery.values('end')[:1]),
+        }
 
 
 class EnterpriseCourseEnrollment(TimeStampedModel):
@@ -1805,6 +1860,7 @@ class EnterpriseCourseEnrollment(TimeStampedModel):
     """
 
     objects = EnterpriseCourseEnrollmentManager()
+    with_additional_fields = EnterpriseCourseEnrollmentWithAdditionalFieldsManager()
 
     class Meta:
         unique_together = (('enterprise_customer_user', 'course_id',),)

--- a/enterprise/templates/enterprise/enterprise_course_enrollment_page.html
+++ b/enterprise/templates/enterprise/enterprise_course_enrollment_page.html
@@ -77,19 +77,21 @@
 
                 <label for="radio{{ forloop.counter0 }}">
                   <strong class="title">{{ course_mode.title }}</strong>
-                  <span class="price">
-                    {{ price_text }}:
-                    {% if course_mode.final_price and course_mode.original_price != course_mode.final_price %}
-                      {% if hide_course_original_price %}
-                        {{ course_mode.final_price }}
+                  {% if not course_mode.hide_price %}
+                    <span class="price">
+                      {{ price_text }}:
+                      {% if course_mode.final_price and course_mode.original_price != course_mode.final_price %}
+                        {% if hide_course_original_price %}
+                          {{ course_mode.final_price }}
+                        {% else %}
+                          <strike>{{ course_mode.original_price }}</strike> {{ course_mode.final_price }}
+                          <div>{{discount_text|safe }}</div>
+                        {% endif %}
                       {% else %}
-                        <strike>{{ course_mode.original_price }}</strike> {{ course_mode.final_price }}
-                        <div>{{discount_text|safe }}</div>
+                        {{ course_mode.original_price }}
                       {% endif %}
-                    {% else %}
-                      {{ course_mode.original_price }}
-                    {% endif %}
-                  </span>
+                    </span>
+                  {% endif %}
                   <span class="description">{{ course_mode.description }}</span>
                 </label>
               </div>

--- a/enterprise/templates/enterprise/templatetags/course_modal.html
+++ b/enterprise/templates/enterprise/templatetags/course_modal.html
@@ -25,7 +25,7 @@
           <ul class="details-list">
             {% if premium_modes|length > 0 %}
               {% with course_mode=premium_modes.0 %}
-                {% if course_mode.original_price %}
+                {% if course_mode.original_price and not course_mode.hide_price %}
                   <li>
                     <div class="detail-container">
                       <div class="detail-title-container">

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -1700,12 +1700,15 @@ def enroll_user(enterprise_customer, user, course_mode, *course_ids, **kwargs):
         user: The user model object who needs to be enrolled in the course
         course_mode: The string representation of the mode with which the enrollment should be created
         *course_ids: An iterable containing any number of course IDs to eventually enroll the user in.
-        kwargs: Should contain enrollment_client if it's already been instantiated and should be passed in.
+        kwargs: Contains optional params such as:
+            - enrollment_client, if it's already been instantiated and should be passed in
+            - force_enrollment, if the course is "Invite Only" and the "force_enrollment" is needed
 
     Returns:
         Boolean: Whether or not enrollment succeeded for all courses specified
     """
     enrollment_client = kwargs.pop('enrollment_client', None)
+    force_enrollment = kwargs.pop('force_enrollment', False)
     if not enrollment_client:
         from enterprise.api_client.lms import EnrollmentApiClient  # pylint: disable=import-outside-toplevel
         enrollment_client = EnrollmentApiClient()
@@ -1720,7 +1723,8 @@ def enroll_user(enterprise_customer, user, course_mode, *course_ids, **kwargs):
                 user.username,
                 course_id,
                 course_mode,
-                enterprise_uuid=str(enterprise_customer_user.enterprise_customer.uuid)
+                enterprise_uuid=str(enterprise_customer_user.enterprise_customer.uuid),
+                force_enrollment=force_enrollment,
             )
         except HttpClientError as exc:
             # Check if user is already enrolled then we should ignore exception
@@ -2059,6 +2063,7 @@ def enroll_users_in_course(
         enrollment_reason=None,
         discount=0.0,
         sales_force_id=None,
+        force_enrollment=False,
 ):
     """
     Enroll existing users in a course, and create a pending enrollment for nonexisting users.
@@ -2072,6 +2077,7 @@ def enroll_users_in_course(
         enrollment_reason (str): A reason for enrollment.
         discount (Decimal): Percentage discount for enrollment.
         sales_force_id (str): Salesforce opportunity id.
+        force_enrollment (bool): Force enrollment into 'Invite Only' courses.
 
     Returns:
         successes: A list of users who were successfully enrolled in the course.
@@ -2088,7 +2094,7 @@ def enroll_users_in_course(
     failures = []
 
     for user in existing_users:
-        succeeded = enroll_user(enterprise_customer, user, course_mode, course_id)
+        succeeded = enroll_user(enterprise_customer, user, course_mode, course_id, force_enrollment=force_enrollment)
         if succeeded:
             successes.append(user)
             if enrollment_requester and enrollment_reason:

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -59,8 +59,10 @@ except ImportError:
 
 try:
     from common.djangoapps.course_modes.models import CourseMode
+    from common.djangoapps.student.models import CourseEnrollmentAllowed
 except ImportError:
     CourseMode = None
+    CourseEnrollmentAllowed = None
 
 try:
     from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
@@ -2313,3 +2315,23 @@ def hide_price_when_zero(enterprise_customer, course_modes):
                 mode['title']
             )
     return course_modes
+
+
+def ensure_course_enrollment_is_allowed(course_id, email, enrollment_api_client):
+    """
+    Create a CourseEnrollmentAllowed object for invitation-only courses.
+
+    Arguments:
+        course_id (str): ID of the course to allow enrollment
+        email (str): email of the user whose enrollment should be allowed
+        enrollment_api_client (:class:`enterprise.api_client.lms.EnrollmentApiClient`): Enrollment API Client
+    """
+    if not CourseEnrollmentAllowed:
+        raise NotConnectedToOpenEdX()
+
+    course_details = enrollment_api_client.get_course_details(course_id)
+    if course_details["invite_only"]:
+        CourseEnrollmentAllowed.objects.update_or_create(
+            course_id=course_id,
+            email=email,
+        )

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -2288,3 +2288,28 @@ def logo_path(instance, filename):
     fullname = os.path.join("enterprise/branding/" + str(instance.enterprise_customer.uuid) +
                             "/logo_" + generated_uuid + extension)
     return fullname
+
+
+def hide_price_when_zero(enterprise_customer, course_modes):
+    """
+    Adds a "hide_price" flag to the course modes if price is zero and "Hide course price when zero" flag is set.
+
+    Arguments:
+        enterprise_customer: The EnterpriseCustomer that the enrollemnt is being done.
+        course_modes: iterable with dictionaries containing a required 'final_price' key
+    """
+    if not enterprise_customer.hide_course_price_when_zero:
+        return course_modes
+
+    for mode in course_modes:
+        mode['hide_price'] = False
+        try:
+            numbers = re.findall(r'\d+', mode['final_price'])
+            mode['hide_price'] = int(''.join(numbers)) == 0
+        except ValueError:
+            LOGGER.warning(
+                'hide_price_when_zero: Could not convert price "%s" of course mode "%s" to int.',
+                mode['final_price'],
+                mode['title']
+            )
+    return course_modes

--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -76,6 +76,7 @@ from enterprise.utils import (
     get_enterprise_customer_user,
     get_platform_logo_url,
     get_program_type_description,
+    hide_price_when_zero,
     is_course_run_enrollable,
     localized_utcnow,
     track_enrollment,
@@ -1541,6 +1542,9 @@ class CourseEnrollmentView(NonAtomicView):
 
             # Filter audit course modes.
             course_modes = filter_audit_course_modes(enterprise_customer, course_modes)
+
+            # Set a flag to hide the $0 when the customer doesn't want it to be shown
+            course_modes = hide_price_when_zero(enterprise_customer, course_modes)
 
             # Allows automatic assignment to a cohort upon enrollment.
             cohort = request.GET.get('cohort')

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,6 +4,7 @@
 #
 #    make upgrade
 #
+
 certifi==2022.9.24
     # via requests
 charset-normalizer==2.1.1

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -8,7 +8,7 @@ certifi==2022.9.24
     # via requests
 charset-normalizer==2.1.1
     # via requests
-codecov==2.1.12
+codecov==2.1.13
     # via -r requirements/ci.in
 coverage==6.5.0
     # via codecov

--- a/test_utils/factories.py
+++ b/test_utils/factories.py
@@ -24,6 +24,8 @@ from enterprise.models import (
     EnterpriseCustomerInviteKey,
     EnterpriseCustomerReportingConfiguration,
     EnterpriseCustomerUser,
+    EnterpriseFeatureRole,
+    EnterpriseFeatureUserRoleAssignment,
     LearnerCreditEnterpriseCourseEnrollment,
     LicensedEnterpriseCourseEnrollment,
     PendingEnrollment,
@@ -263,6 +265,41 @@ class UserFactory(factory.django.DjangoModelFactory):
     is_staff = False
     is_active = False
     date_joined = factory.LazyAttribute(lambda x: FAKER.date_time_this_year(tzinfo=timezone.utc))
+
+
+class EnterpriseFeatureRoleFactory(factory.django.DjangoModelFactory):
+    """
+    EnterpriseFeatureRole factory.
+
+    Creates an instance of EnterpriseFeatureRole with minimal boilerplate.
+    """
+
+    class Meta:
+        """
+        Meta for EnterpriseFeatureRoleFactory.
+        """
+
+        model = EnterpriseFeatureRole
+
+    name = factory.LazyAttribute(lambda x: FAKER.word())
+
+
+class EnterpriseFeatureUserRoleAssignmentFactory(factory.django.DjangoModelFactory):
+    """
+    EnterpriseFeatureUserRoleAssignment factory.
+
+    Creates an instance of EnterpriseFeatureUserRoleAssignment with minimal boilerplate.
+    """
+
+    class Meta:
+        """
+        Meta for EnterpriseFeatureUserRoleAssignmentFactory.
+        """
+
+        model = EnterpriseFeatureUserRoleAssignment
+
+    role = factory.SubFactory(EnterpriseFeatureRoleFactory)
+    user = factory.SubFactory(UserFactory)
 
 
 class AnonymousUserFactory(factory.Factory):

--- a/test_utils/fake_enrollment_api.py
+++ b/test_utils/fake_enrollment_api.py
@@ -150,7 +150,8 @@ def get_course_details(course_id):
         return None
 
 
-def enroll_user_in_course(user, course_id, mode, cohort=None, enterprise_uuid=None):
+def enroll_user_in_course(user, course_id, mode, cohort=None, enterprise_uuid=None, force_enrollment=False):  # pylint: disable=unused-argument
+
     """
     Fake implementation.
     """

--- a/tests/test_admin/test_view.py
+++ b/tests/test_admin/test_view.py
@@ -894,7 +894,16 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
         self._test_post_existing_record_response(response)
         assert PendingEnterpriseCustomerUser.objects.filter(user_email=email).count() == 2
 
-    def _enroll_user_request(self, user, mode, course_id="", notify=True, reason="tests", discount=0.0):
+    def _enroll_user_request(
+        self,
+        user,
+        mode,
+        course_id="",
+        notify=True,
+        reason="tests",
+        discount=0.0,
+        force_enrollment=False
+    ):
         """
         Perform post request to log in and submit the form to enroll a user.
         """
@@ -919,6 +928,7 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
                     ManageLearnersForm.Fields.NOTIFY: notify,
                     ManageLearnersForm.Fields.REASON: reason,
                     ManageLearnersForm.Fields.DISCOUNT: discount,
+                    ManageLearnersForm.Fields.FORCE_ENROLLMENT: force_enrollment,
                 })
         return response
 
@@ -977,7 +987,8 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
             user.username,
             course_id,
             mode,
-            enterprise_uuid=str(self.enterprise_customer.uuid)
+            enterprise_uuid=str(self.enterprise_customer.uuid),
+            force_enrollment=False
         )
         if enrollment_exists:
             track_enrollment.assert_not_called()
@@ -1050,7 +1061,8 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
                     user.username,
                     course_id,
                     mode,
-                    enterprise_uuid=str(self.enterprise_customer.uuid)
+                    enterprise_uuid=str(self.enterprise_customer.uuid),
+                    force_enrollment=False,
                 )
                 track_enrollment.assert_called_with('admin-enrollment', user.id, course_id)
                 self._assert_django_messages(response, {
@@ -1111,13 +1123,17 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
         """
         Test that a pending learner can be enrolled in multiple courses.
         """
-        self._post_multi_enroll(
-            enterprise_catalog_client,
-            enrollment_client,
-            course_catalog_client,
-            track_enrollment,
-            False,
-        )
+        with mock.patch(
+            'enterprise.models.EnrollmentApiClient.get_course_details',
+            wraps=fake_enrollment_api.get_course_details,
+        ):
+            self._post_multi_enroll(
+                enterprise_catalog_client,
+                enrollment_client,
+                course_catalog_client,
+                track_enrollment,
+                False,
+            )
 
     @mock.patch("enterprise.utils.track_enrollment")
     @mock.patch("enterprise.models.CourseCatalogApiClient")
@@ -1146,7 +1162,8 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
             user.username,
             course_id,
             mode,
-            enterprise_uuid=str(self.enterprise_customer.uuid)
+            enterprise_uuid=str(self.enterprise_customer.uuid),
+            force_enrollment=False
         )
         track_enrollment.assert_called_once_with('admin-enrollment', user.id, course_id)
         self._assert_django_messages(response, {
@@ -1162,6 +1179,51 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
         assert enrollment.source.slug == EnterpriseEnrollmentSource.MANUAL
         num_messages = len(mail.outbox)
         assert num_messages == 0
+
+    @mock.patch("enterprise.utils.track_enrollment")
+    @mock.patch("enterprise.models.CourseCatalogApiClient")
+    @mock.patch("enterprise.api_client.lms.EnrollmentApiClient")
+    @mock.patch("enterprise.models.EnterpriseCatalogApiClient")
+    @ddt.data(True, False)
+    def test_post_enroll_force_enrollment(
+            self,
+            force_enrollment,
+            enterprise_catalog_client,
+            enrollment_client,
+            course_catalog_client,
+            track_enrollment,
+    ):
+        catalog_instance = course_catalog_client.return_value
+        catalog_instance.get_course_run.return_value = {}
+        enrollment_instance = enrollment_client.return_value
+        enrollment_instance.enroll_user_in_course.side_effect = fake_enrollment_api.enroll_user_in_course
+        enrollment_instance.get_course_details.side_effect = fake_enrollment_api.get_course_details
+        enterprise_catalog_instance = enterprise_catalog_client.return_value
+        enterprise_catalog_instance.enterprise_contains_content_items.return_value = True
+
+        user = UserFactory()
+        course_id = "course-v1:HarvardX+CoolScience+2016"
+        mode = "verified"
+        response = self._enroll_user_request(user, mode, course_id=course_id, force_enrollment=force_enrollment)
+        enrollment_instance.enroll_user_in_course.assert_called_once_with(
+            user.username,
+            course_id,
+            mode,
+            enterprise_uuid=str(self.enterprise_customer.uuid),
+            force_enrollment=force_enrollment
+        )
+        track_enrollment.assert_called_once_with('admin-enrollment', user.id, course_id)
+        self._assert_django_messages(response, {
+            (messages.SUCCESS, "1 learner was enrolled in {}.".format(course_id)),
+        })
+        all_enterprise_enrollments = EnterpriseCourseEnrollment.objects.all()
+        num_enterprise_enrollments = len(all_enterprise_enrollments)
+        assert num_enterprise_enrollments == 1
+        enrollment = all_enterprise_enrollments[0]
+        assert enrollment.enterprise_customer_user.user == user
+        assert enrollment.course_id == course_id
+        assert enrollment.source is not None
+        assert enrollment.source.slug == EnterpriseEnrollmentSource.MANUAL
 
     @mock.patch("enterprise.utils.track_enrollment")
     @mock.patch("enterprise.models.CourseCatalogApiClient")
@@ -1211,7 +1273,8 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
             user.username,
             course_id,
             mode,
-            enterprise_uuid=str(self.enterprise_customer.uuid)
+            enterprise_uuid=str(self.enterprise_customer.uuid),
+            force_enrollment=False
         )
 
     @mock.patch("enterprise.utils.track_enrollment")
@@ -1245,7 +1308,8 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
             user.username,
             course_id,
             mode,
-            enterprise_uuid=str(self.enterprise_customer.uuid)
+            enterprise_uuid=str(self.enterprise_customer.uuid),
+            force_enrollment=False
         )
         track_enrollment.assert_not_called()
         self._assert_django_messages(response, {
@@ -1286,7 +1350,8 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
             user.username,
             course_id,
             mode,
-            enterprise_uuid=str(self.enterprise_customer.uuid)
+            enterprise_uuid=str(self.enterprise_customer.uuid),
+            force_enrollment=False
         )
         track_enrollment.assert_not_called()
         self._assert_django_messages(response, {
@@ -1331,7 +1396,8 @@ class TestEnterpriseCustomerManageLearnersViewPostSingleUser(BaseTestEnterpriseC
             user.username,
             course_id,
             mode,
-            enterprise_uuid=str(self.enterprise_customer.uuid)
+            enterprise_uuid=str(self.enterprise_customer.uuid),
+            force_enrollment=False
         )
         track_enrollment.assert_called_once_with('admin-enrollment', user.id, course_id)
         self._assert_django_messages(response, {
@@ -1677,6 +1743,7 @@ class TestEnterpriseCustomerManageLearnersViewPostBulkUpload(BaseTestEnterpriseC
                 enrollment_requester=ANY,
                 enterprise_customer=ANY,
                 sales_force_id=ANY,
+                force_enrollment=ANY,
             )
             enroll_users_in_course_mock.assert_any_call(
                 course_id=second_course_id,
@@ -1687,6 +1754,7 @@ class TestEnterpriseCustomerManageLearnersViewPostBulkUpload(BaseTestEnterpriseC
                 enrollment_requester=ANY,
                 enterprise_customer=ANY,
                 sales_force_id=ANY,
+                force_enrollment=ANY,
             )
         else:
             enroll_users_in_course_mock.assert_not_called()
@@ -1771,8 +1839,10 @@ class TestEnterpriseCustomerManageLearnersViewPostBulkUpload(BaseTestEnterpriseC
     @mock.patch("enterprise.models.CourseCatalogApiClient")
     @mock.patch("enterprise.api_client.lms.EnrollmentApiClient")
     @mock.patch("enterprise.models.EnterpriseCatalogApiClient")
+    @mock.patch("enterprise.models.CourseEnrollmentAllowed")
     def test_post_link_and_enroll(
             self,
+            mock_cea,
             enterprise_catalog_client,
             enrollment_client,
             course_catalog_client,
@@ -1805,13 +1875,18 @@ class TestEnterpriseCustomerManageLearnersViewPostBulkUpload(BaseTestEnterpriseC
         course_id = "course-v1:EnterpriseX+Training+2017"
         course_mode = "professional"
 
-        response = self._perform_request(columns, data, course=course_id, course_mode=course_mode)
+        with mock.patch(
+            'enterprise.models.EnrollmentApiClient.get_course_details',
+            wraps=fake_enrollment_api.get_course_details,
+        ):
+            response = self._perform_request(columns, data, course=course_id, course_mode=course_mode)
 
         enrollment_instance.enroll_user_in_course.assert_called_once_with(
             user.username,
             course_id,
             course_mode,
-            enterprise_uuid=str(self.enterprise_customer.uuid)
+            enterprise_uuid=str(self.enterprise_customer.uuid),
+            force_enrollment=False
         )
         track_enrollment.assert_called_once_with('admin-enrollment', user.id, course_id)
         pending_user_message = (
@@ -1830,13 +1905,16 @@ class TestEnterpriseCustomerManageLearnersViewPostBulkUpload(BaseTestEnterpriseC
         assert pending_enrollment.sales_force_id == sales_force_id
         num_messages = len(mail.outbox)
         assert num_messages == 2
+        mock_cea.objects.update_or_create.assert_called_once()
 
     @mock.patch("enterprise.utils.track_enrollment")
     @mock.patch("enterprise.models.CourseCatalogApiClient")
     @mock.patch("enterprise.api_client.lms.EnrollmentApiClient")
     @mock.patch("enterprise.models.EnterpriseCatalogApiClient")
+    @mock.patch("enterprise.models.CourseEnrollmentAllowed")
     def test_post_link_and_enroll_no_course_details(
             self,
+            mock_cea,
             enterprise_catalog_client,
             enrollment_client,
             course_catalog_client,
@@ -1861,13 +1939,18 @@ class TestEnterpriseCustomerManageLearnersViewPostBulkUpload(BaseTestEnterpriseC
         course_id = "course-v1:EnterpriseX+Training+2017"
         course_mode = "professional"
 
-        response = self._perform_request(columns, data, course=course_id, course_mode=course_mode)
+        with mock.patch(
+            'enterprise.models.EnrollmentApiClient.get_course_details',
+            wraps=fake_enrollment_api.get_course_details,
+        ):
+            response = self._perform_request(columns, data, course=course_id, course_mode=course_mode)
 
         enrollment_instance.enroll_user_in_course.assert_called_once_with(
             user.username,
             course_id,
             course_mode,
-            enterprise_uuid=str(self.enterprise_customer.uuid)
+            enterprise_uuid=str(self.enterprise_customer.uuid),
+            force_enrollment=False
         )
         track_enrollment.assert_called_once_with('admin-enrollment', user.id, course_id)
         pending_user_message = (
@@ -1883,12 +1966,15 @@ class TestEnterpriseCustomerManageLearnersViewPostBulkUpload(BaseTestEnterpriseC
         assert PendingEnterpriseCustomerUser.objects.all()[0].pendingenrollment_set.all()[0].course_id == course_id
         num_messages = len(mail.outbox)
         assert num_messages == 0
+        mock_cea.objects.update_or_create.assert_called_once()
 
     @mock.patch("enterprise.utils.track_enrollment")
     @mock.patch("enterprise.api_client.lms.EnrollmentApiClient")
     @mock.patch("enterprise.models.EnterpriseCatalogApiClient")
+    @mock.patch("enterprise.models.CourseEnrollmentAllowed")
     def test_post_link_and_enroll_no_notification(
             self,
+            mock_cea,
             enterprise_catalog_client,
             enrollment_client,
             track_enrollment,
@@ -1910,13 +1996,18 @@ class TestEnterpriseCustomerManageLearnersViewPostBulkUpload(BaseTestEnterpriseC
         course_id = "course-v1:EnterpriseX+Training+2017"
         course_mode = "professional"
 
-        response = self._perform_request(columns, data, course=course_id, course_mode=course_mode, notify=False)
+        with mock.patch(
+            'enterprise.models.EnrollmentApiClient.get_course_details',
+            wraps=fake_enrollment_api.get_course_details,
+        ):
+            response = self._perform_request(columns, data, course=course_id, course_mode=course_mode, notify=False)
 
         enrollment_instance.enroll_user_in_course.assert_called_once_with(
             user.username,
             course_id,
             course_mode,
-            enterprise_uuid=str(self.enterprise_customer.uuid)
+            enterprise_uuid=str(self.enterprise_customer.uuid),
+            force_enrollment=False
         )
         track_enrollment.assert_called_once_with('admin-enrollment', user.id, course_id)
         pending_user_message = (
@@ -1931,6 +2022,7 @@ class TestEnterpriseCustomerManageLearnersViewPostBulkUpload(BaseTestEnterpriseC
         assert PendingEnterpriseCustomerUser.objects.all()[0].pendingenrollment_set.all()[0].course_id == course_id
         num_messages = len(mail.outbox)
         assert num_messages == 0
+        mock_cea.objects.update_or_create.assert_called_once()
 
 
 @mark.django_db

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -65,6 +65,7 @@ from test_utils import (
     update_program_with_enterprise_context,
 )
 from test_utils.factories import FAKER, EnterpriseCustomerUserFactory, PendingEnterpriseCustomerUserFactory, UserFactory
+from test_utils.fake_enrollment_api import get_course_details
 from test_utils.fake_enterprise_api import get_default_branding_object
 
 fake = Faker()
@@ -2340,7 +2341,7 @@ class TestEntepriseCustomerCatalogs(BaseTestEnterpriseAPIViews):
 
 @ddt.ddt
 @mark.django_db
-class TestEnterpriesCustomerCourseEnrollments(BaseTestEnterpriseAPIViews):
+class TestEnterpriseCustomerCourseEnrollments(BaseTestEnterpriseAPIViews):
     """
     Test the Enteprise Customer course enrollments detail route
     """
@@ -2664,6 +2665,7 @@ class TestEnterpriesCustomerCourseEnrollments(BaseTestEnterpriseAPIViews):
             True,
             enable_autocohorting=True
         )
+        mock_enrollment_client.return_value.get_course_details = get_course_details
 
         # Make the call!
         response = self.client.post(
@@ -2861,7 +2863,8 @@ class TestEnterpriesCustomerCourseEnrollments(BaseTestEnterpriseAPIViews):
             get_course_enrollment=mock.Mock(
                 side_effect=[None, {'is_active': True, 'mode': VERIFIED_SUBSCRIPTION_COURSE_MODE}]
             ),
-            enroll_user_in_course=mock.Mock()
+            enroll_user_in_course=mock.Mock(),
+            get_course_details=get_course_details
         )
 
         # Set up catalog_contains_course response.
@@ -3657,6 +3660,7 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
             },
             'expected_num_pending_licenses': 1,
             'expected_events': [mock.call(PATHWAY_CUSTOMER_ADMIN_ENROLLMENT, 1, 'course-v1:edX+DemoX+Demo_Course')],
+            'expected_cea': 0,
         },
         # Validation failure cases
         {
@@ -3665,6 +3669,7 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
             'expected_response': {'non_field_errors': ['Must include the `enrollment_info` parameter in request.']},
             'expected_num_pending_licenses': 0,
             'expected_events': None,
+            'expected_cea': 0,
         },
         {
             'body': {
@@ -3676,6 +3681,7 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
             },
             'expected_num_pending_licenses': 0,
             'expected_events': None,
+            'expected_cea': 0,
         },
         {
             'body': {
@@ -3693,6 +3699,7 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
             },
             'expected_num_pending_licenses': 0,
             'expected_events': None,
+            'expected_cea': 0,
         },
         {
             'body': {
@@ -3718,6 +3725,7 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
             },
             'expected_num_pending_licenses': 0,
             'expected_events': None,
+            'expected_cea': 0,
         },
         {
             'body': {
@@ -3736,6 +3744,7 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
             },
             'expected_num_pending_licenses': 0,
             'expected_events': None,
+            'expected_cea': 0,
         },
         {
             'body': {
@@ -3751,6 +3760,7 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
             },
             'expected_num_pending_licenses': 0,
             'expected_events': None,
+            'expected_cea': 0,
         },
         # Single learner, single course success
         {
@@ -3774,6 +3784,7 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
             },
             'expected_num_pending_licenses': 1,
             'expected_events': [mock.call(PATHWAY_CUSTOMER_ADMIN_ENROLLMENT, 1, 'course-v1:edX+DemoX+Demo_Course')],
+            'expected_cea': 0,
         },
         # Multi-learner, single course success
         {
@@ -3814,6 +3825,7 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
             'expected_events': [
                 mock.call(PATHWAY_CUSTOMER_ADMIN_ENROLLMENT, 1, 'course-v1:edX+DemoX+Demo_Course'),
             ],
+            'expected_cea': 0,
         },
         # Multi-learner, multi-course success
         {
@@ -3831,12 +3843,12 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
                     },
                     {
                         'email': 'abc@test.com',
-                        'course_run_key': 'course-v2:edX+DemoX+Second_Demo_Course',
+                        'course_run_key': 'course-v1:EnterpriseX+Training+2017',
                         'license_uuid': '5a88bdcade7c4ecb838f8111b68e18ac'
                     },
                     {
                         'email': 'xyz@test.com',
-                        'course_run_key': 'course-v2:edX+DemoX+Second_Demo_Course',
+                        'course_run_key': 'course-v1:EnterpriseX+Training+2017',
                         'license_uuid': '2c58acdade7c4ede838f7111b42e18ac'
                     },
                 ]
@@ -3859,13 +3871,13 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
                     },
                     {
                         'email': 'abc@test.com',
-                        'course_run_key': 'course-v2:edX+DemoX+Second_Demo_Course',
+                        'course_run_key': 'course-v1:EnterpriseX+Training+2017',
                         'created': True,
                         'activation_link': None,
                     },
                     {
                         'email': 'xyz@test.com',
-                        'course_run_key': 'course-v2:edX+DemoX+Second_Demo_Course',
+                        'course_run_key': 'course-v1:EnterpriseX+Training+2017',
                         'created': True,
                         'activation_link': None,
                     }
@@ -3875,8 +3887,9 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
             'expected_num_pending_licenses': 4,
             'expected_events': [
                 mock.call(PATHWAY_CUSTOMER_ADMIN_ENROLLMENT, 1, 'course-v1:edX+DemoX+Demo_Course'),
-                mock.call(PATHWAY_CUSTOMER_ADMIN_ENROLLMENT, 1, 'course-v2:edX+DemoX+Second_Demo_Course')
+                mock.call(PATHWAY_CUSTOMER_ADMIN_ENROLLMENT, 1, 'course-v1:EnterpriseX+Training+2017')
             ],
+            'expected_cea': 2,
         },
         {
             'body': {
@@ -3893,12 +3906,12 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
                     },
                     {
                         'email': 'abc@test.com',
-                        'course_run_key': 'course-v2:edX+DemoX+Second_Demo_Course',
+                        'course_run_key': 'course-v1:EnterpriseX+Training+2017',
                         'license_uuid': '5a88bdcade7c4ecb838f8111b68e18ac'
                     },
                     {
                         'email': 'xyz@test.com',
-                        'course_run_key': 'course-v2:edX+DemoX+Second_Demo_Course',
+                        'course_run_key': 'course-v1:EnterpriseX+Training+2017',
                         'license_uuid': '2c58acdade7c4ede838f7111b42e18ac'
                     },
                 ]
@@ -3921,13 +3934,13 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
                     },
                     {
                         'email': 'abc@test.com',
-                        'course_run_key': 'course-v2:edX+DemoX+Second_Demo_Course',
+                        'course_run_key': 'course-v1:EnterpriseX+Training+2017',
                         'created': True,
                         'activation_link': None,
                     },
                     {
                         'email': 'xyz@test.com',
-                        'course_run_key': 'course-v2:edX+DemoX+Second_Demo_Course',
+                        'course_run_key': 'course-v1:EnterpriseX+Training+2017',
                         'created': True,
                         'activation_link': None,
                     }
@@ -3937,16 +3950,19 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
             'expected_num_pending_licenses': 4,
             'expected_events': [
                 mock.call(PATHWAY_CUSTOMER_ADMIN_ENROLLMENT, 1, 'course-v1:edX+DemoX+Demo_Course'),
-                mock.call(PATHWAY_CUSTOMER_ADMIN_ENROLLMENT, 1, 'course-v2:edX+DemoX+Second_Demo_Course')
+                mock.call(PATHWAY_CUSTOMER_ADMIN_ENROLLMENT, 1, 'course-v1:EnterpriseX+Training+2017')
             ],
+            'expected_cea': 2,
         },
     )
     @ddt.unpack
     @mock.patch('enterprise.api.v1.views.get_best_mode_from_course_key')
     @mock.patch('enterprise.api.v1.views.track_enrollment')
     @mock.patch("enterprise.models.EnterpriseCustomer.notify_enrolled_learners")
+    @mock.patch("enterprise.models.CourseEnrollmentAllowed")
     def test_bulk_enrollment_in_bulk_courses_pending_licenses(
         self,
+        mock_cea,
         mock_notify_task,
         mock_track_enroll,
         mock_get_course_mode,
@@ -3955,6 +3971,7 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
         expected_response,
         expected_num_pending_licenses,
         expected_events,
+        expected_cea,
     ):
         """
         Tests the bulk enrollment endpoint at enroll_learners_in_courses.
@@ -3971,11 +3988,17 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
         mock_get_course_mode.return_value = VERIFIED_SUBSCRIPTION_COURSE_MODE
 
         self.assertEqual(len(PendingEnrollment.objects.all()), 0)
-        response = self.client.post(
-            settings.TEST_SERVER + ENTERPRISE_CUSTOMER_BULK_ENROLL_LEARNERS_IN_COURSES_ENDPOINT,
-            data=json.dumps(body),
-            content_type='application/json',
-        )
+
+        with mock.patch(
+            "enterprise.models.EnrollmentApiClient.get_course_details",
+            wraps=get_course_details
+        ):
+            response = self.client.post(
+                settings.TEST_SERVER + ENTERPRISE_CUSTOMER_BULK_ENROLL_LEARNERS_IN_COURSES_ENDPOINT,
+                data=json.dumps(body),
+                content_type='application/json',
+            )
+
         self.assertEqual(response.status_code, expected_code)
         if expected_response:
             response_json = response.json()
@@ -3989,6 +4012,8 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
             mock_track_enroll.assert_has_calls(expected_events[x] for x in range(len(expected_events) - 1))
         else:
             mock_track_enroll.assert_not_called()
+
+        self.assertEqual(mock_cea.objects.update_or_create.call_count, expected_cea)
 
         # no notifications to be sent unless 'notify' specifically asked for in payload
         mock_notify_task.assert_not_called()
@@ -4229,12 +4254,12 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
                     },
                     {
                         'email': 'abc@test.com',
-                        'course_run_key': 'course-v2:edX+DemoX+Second_Demo_Course',
+                        'course_run_key': 'course-v1:HarvardX+CoolScience+2016',
                         'license_uuid': '5a88bdcade7c4ecb838f8111b68e18ac'
                     },
                     {
                         'email': 'xyz@test.com',
-                        'course_run_key': 'course-v2:edX+DemoX+Second_Demo_Course',
+                        'course_run_key': 'course-v1:HarvardX+CoolScience+2016',
                         'license_uuid': '2c58acdade7c4ede838f7111b42e18ac'
                     },
                 ]
@@ -4257,13 +4282,13 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
                     },
                     {
                         'email': 'abc@test.com',
-                        'course_run_key': 'course-v2:edX+DemoX+Second_Demo_Course',
+                        'course_run_key': 'course-v1:HarvardX+CoolScience+2016',
                         'created': True,
                         'activation_link': None,
                     },
                     {
                         'email': 'xyz@test.com',
-                        'course_run_key': 'course-v2:edX+DemoX+Second_Demo_Course',
+                        'course_run_key': 'course-v1:HarvardX+CoolScience+2016',
                         'created': True,
                         'activation_link': None,
                     }
@@ -4308,13 +4333,14 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
 
         self.assertEqual(len(PendingEnrollment.objects.all()), 0)
 
-        response = self.client.post(
-            settings.TEST_SERVER + ENTERPRISE_CUSTOMER_BULK_ENROLL_LEARNERS_IN_COURSES_ENDPOINT,
-            data=json.dumps(body),
-            content_type='application/json',
-        )
-        self.assertEqual(response.status_code, expected_code)
+        with mock.patch("enterprise.models.EnrollmentApiClient.get_course_details", wraps=get_course_details):
+            response = self.client.post(
+                settings.TEST_SERVER + ENTERPRISE_CUSTOMER_BULK_ENROLL_LEARNERS_IN_COURSES_ENDPOINT,
+                data=json.dumps(body),
+                content_type='application/json',
+            )
 
+        self.assertEqual(response.status_code, expected_code)
         response_json = response.json()
         self.assertEqual(expected_response, response_json)
         self.assertEqual(len(PendingEnrollment.objects.all()), expected_num_pending_licenses)

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -1223,10 +1223,17 @@ class TestEnterpriseCustomerViewSet(BaseTestEnterpriseAPIViews):
             [{
                 'enterprise_customer_user__id': 1,
                 'course_id': 'course-v1:edX+DemoX+DemoCourse',
+                'created': '2021-10-20T19:01:31Z',
             }],
             [{
                 'enterprise_customer_user': 1,
                 'course_id': 'course-v1:edX+DemoX+DemoCourse',
+                'created': '2021-10-20T19:01:31Z',
+                'enrollment_date': None,
+                'enrollment_track': None,
+                'user_email': None,
+                'course_start': None,
+                'course_end': None,
             }],
         ),
         (
@@ -3182,6 +3189,7 @@ class TestEnterpriseSubsidyFulfillmentViewSet(BaseTestEnterpriseAPIViews):
             'enterprise_course_enrollment': {
                 'enterprise_customer_user': self.enterprise_user.id,
                 'course_id': self.enterprise_course_enrollment.course_id,
+                'created': self.enterprise_course_enrollment.created.strftime("%Y-%m-%dT%H:%M:%SZ"),
             }
         }
 
@@ -3200,6 +3208,7 @@ class TestEnterpriseSubsidyFulfillmentViewSet(BaseTestEnterpriseAPIViews):
             'enterprise_course_enrollment': {
                 'enterprise_customer_user': self.enterprise_user.id,
                 'course_id': self.enterprise_course_enrollment.course_id,
+                'created': self.enterprise_course_enrollment.created.strftime("%Y-%m-%dT%H:%M:%SZ"),
             }
         }
 

--- a/tests/test_enterprise/api_client/test_lms.py
+++ b/tests/test_enterprise/api_client/test_lms.py
@@ -99,7 +99,8 @@ def test_enroll_user_in_course():
         mode=mode,
         cohort=cohort,
         is_active=True,
-        enterprise_uuid='None'
+        enterprise_uuid='None',
+        force_enrollment=False
     )
     responses.add(
         responses.POST,

--- a/tests/test_enterprise/test_utils.py
+++ b/tests/test_enterprise/test_utils.py
@@ -21,6 +21,7 @@ from enterprise.utils import (
     serialize_notification_content,
 )
 from test_utils import FAKE_UUIDS, TEST_PASSWORD, TEST_USERNAME, factories
+from test_utils.fake_enrollment_api import get_course_details
 
 LMS_BASE_URL = 'https://lms.base.url'
 
@@ -401,11 +402,12 @@ class TestUtils(unittest.TestCase):
         )
         licensed_users_info = [{
             'email': 'pending-user-email@example.com',
-            'course_run_key': 'course-key-v1',
+            'course_run_key': 'course-v1:edX+DemoX+Demo_Course',
             'course_mode': 'verified',
             'license_uuid': '5b77bdbade7b4fcb838f8111b68e18ae'
         }]
-        result = enroll_subsidy_users_in_courses(ent_customer, licensed_users_info)
+        with mock.patch("enterprise.models.EnrollmentApiClient.get_course_details", wraps=get_course_details):
+            result = enroll_subsidy_users_in_courses(ent_customer, licensed_users_info)
 
         self.assertEqual(result['pending'][0]['email'], 'pending-user-email@example.com')
         self.assertFalse(result['successes'])

--- a/tests/test_enterprise/test_utils.py
+++ b/tests/test_enterprise/test_utils.py
@@ -14,6 +14,7 @@ from django.forms.models import model_to_dict
 from enterprise.models import EnterpriseCourseEnrollment, LicensedEnterpriseCourseEnrollment
 from enterprise.utils import (
     enroll_subsidy_users_in_courses,
+    ensure_course_enrollment_is_allowed,
     get_idiff_list,
     get_platform_logo_url,
     hide_price_when_zero,
@@ -520,3 +521,23 @@ class TestUtils(unittest.TestCase):
         else:
             self.assertEqual(zero_modes, processed_zero_modes)
             self.assertEqual(non_zero_modes, processed_non_zero_modes)
+
+    @ddt.data(True, False)
+    @mock.patch("enterprise.utils.CourseEnrollmentAllowed")
+    def test_ensure_course_enrollment_is_allowed(self, invite_only, mock_cea):
+        """
+        Test that the CourseEnrollmentAllowed is created only for the "invite_only" courses.
+        """
+        self.create_user()
+        mock_enrollment_api = mock.Mock()
+        mock_enrollment_api.get_course_details.return_value = {"invite_only": invite_only}
+
+        ensure_course_enrollment_is_allowed("test-course-id", self.user.email, mock_enrollment_api)
+
+        if invite_only:
+            mock_cea.objects.update_or_create.assert_called_with(
+                course_id="test-course-id",
+                email=self.user.email
+            )
+        else:
+            mock_cea.objects.update_or_create.assert_not_called()

--- a/tests/test_enterprise/test_utils.py
+++ b/tests/test_enterprise/test_utils.py
@@ -16,6 +16,7 @@ from enterprise.utils import (
     enroll_subsidy_users_in_courses,
     get_idiff_list,
     get_platform_logo_url,
+    hide_price_when_zero,
     is_pending_user,
     parse_lms_api_datetime,
     serialize_notification_content,
@@ -492,3 +493,30 @@ class TestUtils(unittest.TestCase):
 
         expected_email_items = [expected_email_item(user, activation_links) for user in users]
         assert email_items == expected_email_items
+
+    @ddt.data(True, False)
+    def test_hide_course_price_when_zero(self, hide_price):
+        customer = factories.EnterpriseCustomerFactory()
+        zero_modes = [
+            {"final_price": "$0"},
+            {"final_price": "$0.000"},
+            {"final_price": "Rs. 0.00"},
+            {"final_price": "0.00 EURO"},
+        ]
+        non_zero_modes = [
+            {"final_price": "$100"},
+            {"final_price": "$73.50"},
+            {"final_price": "Rs.8000.00"},
+            {"final_price": "4000 Euros"},
+        ]
+        customer.hide_course_price_when_zero = hide_price
+
+        processed_zero_modes = hide_price_when_zero(customer, zero_modes)
+        processed_non_zero_modes = hide_price_when_zero(customer, non_zero_modes)
+
+        if hide_price:
+            self.assertTrue(all(mode["hide_price"] for mode in processed_zero_modes))
+            self.assertFalse(all(mode["hide_price"] for mode in processed_non_zero_modes))
+        else:
+            self.assertEqual(zero_modes, processed_zero_modes)
+            self.assertEqual(non_zero_modes, processed_non_zero_modes)

--- a/tests/test_enterprise/views/test_course_enrollment_view.py
+++ b/tests/test_enterprise/views/test_course_enrollment_view.py
@@ -1618,6 +1618,58 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
             fetch_redirect_response=False
         )
 
+    @mock.patch('enterprise.views.render', side_effect=fake_render)
+    @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
+    @mock.patch('enterprise.views.EnrollmentApiClient')
+    @mock.patch('enterprise.views.get_data_sharing_consent')
+    @mock.patch('enterprise.utils.Registry')
+    @mock.patch('enterprise.utils.CourseEnrollmentAllowed')
+    def test_post_course_specific_enrollment_view_invite_only_courses(
+            self,
+            mock_cea,
+            registry_mock,
+            get_data_sharing_consent_mock,
+            enrollment_api_client_mock,
+            catalog_api_client_mock,
+            *args
+    ):
+        course_id = self.demo_course_id
+        get_data_sharing_consent_mock.return_value = mock.MagicMock(consent_required=mock.MagicMock(return_value=False))
+        setup_course_catalog_api_client_mock(catalog_api_client_mock)
+        self._setup_enrollment_client(enrollment_api_client_mock)
+        enrollment_api_client_mock.return_value.get_course_details.return_value = {"invite_only": True}
+
+        enterprise_customer = EnterpriseCustomerFactory(
+            name='Starfleet Academy',
+            enable_data_sharing_consent=False,
+            enable_audit_enrollment=False,
+            allow_enrollment_in_invite_only_courses=True,
+        )
+        EnterpriseCustomerCatalogFactory(enterprise_customer=enterprise_customer)
+        self._setup_registry_mock(registry_mock, self.provider_id)
+        EnterpriseCustomerIdentityProviderFactory(provider_id=self.provider_id, enterprise_customer=enterprise_customer)
+        self._login()
+        course_enrollment_page_url = self._append_fresh_login_param(
+            reverse(
+                'enterprise_course_run_enrollment_page',
+                args=[enterprise_customer.uuid, course_id],
+            )
+        )
+        enterprise_catalog_uuid = str(enterprise_customer.enterprise_customer_catalogs.first().uuid)
+
+        response = self.client.post(
+            course_enrollment_page_url, {
+                'course_mode': 'professional',
+                'catalog': enterprise_catalog_uuid
+            }
+        )
+
+        mock_cea.objects.update_or_create.assert_called_with(
+            course_id=course_id,
+            email=self.user.email
+        )
+        assert response.status_code == 302
+
     @mock.patch('enterprise.api_client.ecommerce.configuration_helpers')
     @mock.patch('enterprise.views.render', side_effect=fake_render)
     @mock.patch('enterprise.api_client.lms.embargo_api')

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -134,6 +134,7 @@ class TestEnterpriseUtils(unittest.TestCase):
                 "uuid",
                 "name",
                 "slug",
+                "allow_enrollment_in_invite_only_courses",
                 "active",
                 "country",
                 "invite_keys",

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -167,6 +167,7 @@ class TestEnterpriseUtils(unittest.TestCase):
                 "system_wide_role_assignments",
                 "reply_to",
                 "hide_labor_market_data",
+                "hide_course_price_when_zero",
             ]
         ),
         (


### PR DESCRIPTION
## Description

Nutmeg uses `3.42.5`: https://github.com/openedx/edx-platform/blob/open-release/nutmeg.3/requirements/constraints.txt#L34

Diff between `opencraft-release/nutmeg.2` and `3.42.5`: https://github.com/openedx/edx-enterprise/compare/3.42.5...open-craft:edx-enterprise:opencraft-release/nutmeg.2?expand=1:

| Commit                                   | Related PR                                          | Upstream PR                                         | Note                                                                                                                 |
| ---------------------------------------- | --------------------------------------------------- | --------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
| 1be2ff9547fc77732bc646bd46c0a467b5128fa8 | https://github.com/open-craft/edx-enterprise/pull/3 | https://github.com/openedx/edx-enterprise/pull/1714 | Squashed into a single commit.                                                                                       |
| 8c499ec8a63aca04fb266b4cb2507c98589e483a | https://github.com/open-craft/edx-enterprise/pull/4 | https://github.com/openedx/edx-enterprise/pull/1748 |                                                                                                                      |
| cc0b2ade51de4d7fc1e41ebdf25ec76c5ca3cc74 | https://github.com/open-craft/edx-enterprise/pull/5 | https://github.com/openedx/edx-enterprise/pull/1714 | This was just an update of the first pull request. Not needed, since I cherry-picked the recent version.             | 
| bbafc5ef420820eb0dd301938091b014135bdb9f | https://github.com/open-craft/edx-enterprise/pull/6 | https://github.com/openedx/edx-enterprise/pull/1788 | Squashed into a single commit, extracted migrations.                                                                 |
| 65cee2cdb9da0ceee7e785f11d0524ea45e259c0 | https://github.com/open-craft/edx-enterprise/pull/7 | https://github.com/openedx/edx-enterprise/pull/1813 | Squashed into a single commit, extracted migrations.                                                                 |
| 4e6e348832531cab9d3c5d43e9f5f1384997f67b | https://github.com/open-craft/edx-enterprise/pull/8 | None                                                | Replaced with https://github.com/open-craft/edx-enterprise/pull/10/commits/9840c0bb4457a63ad1b6e476845c7481ecbd2f58. |

## Testing notes:

Testing this was extremely tedious, so I'm not providing exact steps that I performed to make the devstack and all enterprise-related services work together (I'll post them somewhere after I compile my notes). But, I successfully followed **all** testing steps for the following pull requests:

- https://github.com/openedx/edx-enterprise/pull/1714
- https://github.com/openedx/edx-enterprise/pull/1748
- https://github.com/openedx/edx-enterprise/pull/1788
- https://github.com/openedx/edx-enterprise/pull/1813