### PR TITLE
fix: respect allow_enrollment_in_invite_only_courses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [master]
   pull_request:
-    branches: [master]
 
 concurrency:
   group: ci-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/mysql8-migrations.yml
+++ b/.github/workflows/mysql8-migrations.yml
@@ -56,7 +56,7 @@ jobs:
         pip uninstall -y mysqlclient
         pip install --no-binary mysqlclient mysqlclient
         pip uninstall -y xmlsec
-        pip install --no-binary xmlsec xmlsec
+        pip install --no-binary xmlsec xmlsec==1.3.13
         pip install backports.zoneinfo
     - name: Initiate Services
       run: |

--- a/enterprise/admin/__init__.py
+++ b/enterprise/admin/__init__.py
@@ -202,7 +202,7 @@ class EnterpriseCustomerAdmin(DjangoObjectActions, SimpleHistoryAdmin):
         ('Integration and learning platform settings', {
             'fields': ('enable_portal_lms_configurations_screen', 'enable_portal_saml_configuration_screen',
                        'enable_slug_login', 'replace_sensitive_sso_username', 'hide_course_original_price',
-                       'enable_generation_of_api_credentials')
+                       'enable_generation_of_api_credentials', 'allow_enrollment_in_invite_only_courses')
         }),
         ('Recommended default settings for all enterprise customers', {
             'fields': ('site', 'customer_type', 'enable_learner_portal',

--- a/enterprise/api/v1/views/enterprise_customer.py
+++ b/enterprise/api/v1/views/enterprise_customer.py
@@ -38,6 +38,7 @@ from enterprise.logging import getEnterpriseLogger
 from enterprise.utils import (
     enroll_subsidy_users_in_courses,
     get_best_mode_from_course_key,
+    get_course_details_from_course_keys,
     track_enrollment,
     validate_email_to_link,
 )
@@ -241,6 +242,8 @@ class EnterpriseCustomerViewSet(EnterpriseReadWriteModelViewSet):
         for course_run in course_runs_modes:
             course_runs_modes[course_run] = get_best_mode_from_course_key(course_run)
 
+        course_details = get_course_details_from_course_keys(course_runs_modes.keys())
+
         emails = set()
 
         for info in enrollments_info:
@@ -254,6 +257,7 @@ class EnterpriseCustomerViewSet(EnterpriseReadWriteModelViewSet):
             else:
                 emails.add(info['email'])
             info['course_mode'] = course_runs_modes[info['course_run_key']]
+            info['invitation_only'] = course_details[info['course_run_key']].invitation_only
 
         for email in emails:
             try:

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -2407,19 +2407,14 @@ def truncate_string(string, max_length=MAX_ALLOWED_TEXT_LENGTH):
 
 def ensure_course_enrollment_is_allowed(course_id, email, enrollment_api_client):
     """
-    Create a CourseEnrollmentAllowed object for invitation-only courses.
+    Calls the enrollment API to create a CourseEnrollmentAllowed object for
+    invitation-only courses.
 
     Arguments:
         course_id (str): ID of the course to allow enrollment
         email (str): email of the user whose enrollment should be allowed
         enrollment_api_client (:class:`enterprise.api_client.lms.EnrollmentApiClient`): Enrollment API Client
     """
-    if not CourseEnrollmentAllowed:
-        raise NotConnectedToOpenEdX()
-
     course_details = enrollment_api_client.get_course_details(course_id)
     if course_details["invite_only"]:
-        CourseEnrollmentAllowed.objects.update_or_create(
-            course_id=course_id,
-            email=email,
-        )
+        enrollment_api_client.allow_enrollment(email, course_id)

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -59,6 +59,11 @@ except ImportError:
     CourseEnrollmentError = None
 
 try:
+    from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+except ImportError:
+    CourseOverview = None
+
+try:
     from common.djangoapps.course_modes.models import CourseMode
     from common.djangoapps.student.models import CourseEnrollmentAllowed
 except ImportError:
@@ -2028,6 +2033,7 @@ def enroll_subsidy_users_in_courses(enterprise_customer, subsidy_users_info, dis
         user_id = subsidy_user_info.get('user_id')
         user_email = subsidy_user_info['email'].strip().lower() if 'email' in subsidy_user_info else None
         course_mode = subsidy_user_info.get('course_mode')
+        invitation_only = subsidy_user_info.get('invitation_only')
         course_run_key = subsidy_user_info.get('course_run_key')
         license_uuid = subsidy_user_info.get('license_uuid')
         transaction_id = subsidy_user_info.get('transaction_id')
@@ -2054,6 +2060,12 @@ def enroll_subsidy_users_in_courses(enterprise_customer, subsidy_users_info, dis
                 enrollment_source = enterprise_enrollment_source_model().get_source(
                     enterprise_enrollment_source_model().CUSTOMER_ADMIN
                 )
+                if invitation_only and enterprise_customer.allow_enrollment_in_invite_only_courses:
+                    CourseEnrollmentAllowed.objects.update_or_create(
+                        course_id=course_run_key,
+                        email=user.email,
+                    )
+
                 succeeded, created, source_uuid = customer_admin_enroll_user_with_status(
                     enterprise_customer,
                     user,
@@ -2289,6 +2301,14 @@ def get_best_mode_from_course_key(course_key):
     if best_mode := [mode for mode in BEST_MODE_ORDER if mode in course_modes]:
         return best_mode[0]
     return CourseModes.AUDIT
+
+
+def get_course_details_from_course_keys(course_keys):
+    """
+    Helper to get a mapping of course keys to course details.
+    """
+    course_overviews = CourseOverview.objects.filter(id__in=course_keys)
+    return {str(course_overview.id): course_overview for course_overview in course_overviews}
 
 
 def parse_lms_api_datetime(datetime_string, datetime_format=LMS_API_DATETIME_FORMAT):

--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -683,6 +683,15 @@ class GrantDataSharingPermissions(View):
                         existing_enrollment.get('mode') == constants.CourseModes.AUDIT or
                         existing_enrollment.get('is_active') is False
                 ):
+                    if enterprise_customer.allow_enrollment_in_invite_only_courses:
+                        ensure_course_enrollment_is_allowed(course_id, request.user.email, enrollment_api_client)
+                        LOGGER.info(
+                            'User {user} is allowed to enroll in Course {course_id}.'.format(
+                                user=request.user.username,
+                                course_id=course_id
+                            )
+                        )
+
                     course_mode = get_best_mode_from_course_key(course_id)
                     LOGGER.info(
                         'Retrieved Course Mode: {course_modes} for Course {course_id}'.format(

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -4512,7 +4512,6 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
         mock_update_or_create_enrollment.return_value = True
         mock_get_course_details.return_value.__getitem__.return_value.invitation_only = False
 
-
         user_one = factories.UserFactory(is_active=True)
         user_two = factories.UserFactory(is_active=True)
 
@@ -5001,6 +5000,7 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
                 },
             ]
         }
+
         def enroll():
             self.client.post(
                 settings.TEST_SERVER + reverse(

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -4437,6 +4437,7 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
         },
     )
     @ddt.unpack
+    @mock.patch('enterprise.api.v1.views.enterprise_customer.get_course_details_from_course_keys')
     @mock.patch('enterprise.api.v1.views.enterprise_customer.get_best_mode_from_course_key')
     @mock.patch('enterprise.api.v1.views.enterprise_customer.track_enrollment')
     @mock.patch("enterprise.models.EnterpriseCustomer.notify_enrolled_learners")
@@ -4445,6 +4446,7 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
         mock_notify_task,
         mock_track_enroll,
         mock_get_course_mode,
+        mock_get_course_details,
         body,
         expected_code,
         expected_response,
@@ -4464,6 +4466,7 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
         permission = Permission.objects.get(name='Can add Enterprise Customer')
         self.user.user_permissions.add(permission)
         mock_get_course_mode.return_value = VERIFIED_SUBSCRIPTION_COURSE_MODE
+        mock_get_course_details.return_value.__getitem__.return_value.invitation_only = False
 
         self.assertEqual(len(PendingEnrollment.objects.all()), 0)
         response = self.client.post(
@@ -4488,6 +4491,7 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
         # no notifications to be sent unless 'notify' specifically asked for in payload
         mock_notify_task.assert_not_called()
 
+    @mock.patch('enterprise.api.v1.views.enterprise_customer.get_course_details_from_course_keys')
     @mock.patch('enterprise.api.v1.views.enterprise_customer.get_best_mode_from_course_key')
     @mock.patch('enterprise.api.v1.views.enterprise_customer.track_enrollment')
     @mock.patch('enterprise.models.EnterpriseCustomer.notify_enrolled_learners')
@@ -4498,6 +4502,7 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
         mock_notify_task,
         mock_track_enroll,
         mock_get_course_mode,
+        mock_get_course_details,
     ):
         """
         Tests the bulk enrollment endpoint at enroll_learners_in_courses.
@@ -4505,6 +4510,8 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
         This tests the case where existing users are supplied, so the enrollments are fulfilled rather than pending.
         """
         mock_update_or_create_enrollment.return_value = True
+        mock_get_course_details.return_value.__getitem__.return_value.invitation_only = False
+
 
         user_one = factories.UserFactory(is_active=True)
         user_two = factories.UserFactory(is_active=True)
@@ -4575,6 +4582,7 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
 
         assert mock_update_or_create_enrollment.call_count == 2
 
+    @mock.patch('enterprise.api.v1.views.enterprise_customer.get_course_details_from_course_keys')
     @mock.patch('enterprise.api.v1.views.enterprise_customer.get_best_mode_from_course_key')
     @mock.patch('enterprise.api.v1.views.enterprise_customer.track_enrollment')
     @mock.patch('enterprise.models.EnterpriseCustomer.notify_enrolled_learners')
@@ -4583,12 +4591,15 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
         mock_notify_task,
         mock_track_enroll,
         mock_get_course_mode,
+        mock_get_course_details,
     ):
         """
         Tests the bulk enrollment endpoint at enroll_learners_in_courses.
 
         This tests the case where a non-existent user_id is supplied, so an error should occur.
         """
+        mock_get_course_details.return_value.__getitem__.return_value.invitation_only = False
+
         user = factories.UserFactory(is_active=True)
 
         factories.EnterpriseCustomerFactory(
@@ -4647,6 +4658,7 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
         },
     )
     @ddt.unpack
+    @mock.patch("enterprise.api.v1.views.enterprise_customer.get_course_details_from_course_keys")
     @mock.patch("enterprise.api.v1.views.enterprise_subsidy_fulfillment.enrollment_api")
     @mock.patch(
         'enterprise.api.v1.views.enterprise_customer.get_best_mode_from_course_key'
@@ -4657,6 +4669,7 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
         mock_platform_enrollment,
         mock_get_course_mode,
         mock_update_or_create_enrollment,
+        mock_get_course_details,
         old_transaction_id,
         new_transaction_id,
     ):
@@ -4666,6 +4679,7 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
         """
         mock_platform_enrollment.return_value = True
         mock_get_course_mode.return_value = VERIFIED_SUBSCRIPTION_COURSE_MODE
+        mock_get_course_details.return_value.__getitem__.return_value.invitation_only = False
         # Needed for the cancel endpoint:
         mock_update_or_create_enrollment.update_enrollment.return_value = mock.Mock()
 
@@ -4768,12 +4782,14 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
         },
     )
     @ddt.unpack
+    @mock.patch('enterprise.api.v1.views.enterprise_customer.get_course_details_from_course_keys')
     @mock.patch('enterprise.api.v1.views.enterprise_customer.get_best_mode_from_course_key')
     @mock.patch('enterprise.utils.lms_update_or_create_enrollment')
     def test_bulk_enrollment_includes_fulfillment_source_uuid(
         self,
         mock_get_course_mode,
         mock_update_or_create_enrollment,
+        mock_get_course_details,
         body,
         fulfillment_source,
     ):
@@ -4782,6 +4798,7 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
         generated subsidized enrollment uuid value as part of the response payload.
         """
         mock_update_or_create_enrollment.return_value = True
+        mock_get_course_details.return_value.__getitem__.return_value.invitation_only = False
 
         user, _, enterprise_customer = self._create_user_and_enterprise_customer(
             body.get('enrollments_info')[0].get('email'), 'test_password'
@@ -4878,6 +4895,7 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
         },
     )
     @ddt.unpack
+    @mock.patch('enterprise.api.v1.views.enterprise_customer.get_course_details_from_course_keys')
     @mock.patch('enterprise.api.v1.views.enterprise_customer.get_best_mode_from_course_key')
     @mock.patch('enterprise.api.v1.views.enterprise_customer.track_enrollment')
     @mock.patch("enterprise.models.EnterpriseCustomer.notify_enrolled_learners")
@@ -4886,6 +4904,7 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
         mock_notify_task,
         mock_track_enroll,
         mock_get_course_mode,
+        mock_get_course_details,
         body,
         expected_code,
         expected_response,
@@ -4905,6 +4924,7 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
         permission = Permission.objects.get(name='Can add Enterprise Customer')
         self.user.user_permissions.add(permission)
         mock_get_course_mode.return_value = VERIFIED_SUBSCRIPTION_COURSE_MODE
+        mock_get_course_details.return_value.__getitem__.return_value.invitation_only = False
 
         self.assertEqual(len(PendingEnrollment.objects.all()), 0)
 
@@ -4951,12 +4971,71 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
 
         mock_notify_task.assert_has_calls(mock_calls, any_order=True)
 
+    @mock.patch('enterprise.utils.CourseEnrollmentAllowed')
+    @mock.patch('enterprise.api.v1.views.enterprise_customer.get_course_details_from_course_keys')
+    @mock.patch('enterprise.api.v1.views.enterprise_customer.get_best_mode_from_course_key')
+    @mock.patch('enterprise.utils.lms_update_or_create_enrollment')
+    def test_bulk_enrollment_invitation_only(
+        self,
+        mock_update_or_create_enrollment,
+        mock_get_course_mode,
+        mock_get_course_details,
+        mock_cea,
+    ):
+        """
+        Tests that bulk enrollment endpoint creates CourseEnrollmentAllowed object when enterprise customer allows
+        enrollment in invitation only courses and the course is invitation only.
+        """
+        mock_update_or_create_enrollment.return_value = True
+        mock_get_course_details.return_value.__getitem__.return_value.invitation_only = True
+        mock_get_course_mode.return_value = VERIFIED_SUBSCRIPTION_COURSE_MODE
+
+        user, _, enterprise_customer = self._create_user_and_enterprise_customer("abc@test.com", "test_password")
+        course_id = 'course-v1:edX+DemoX+Demo_Course'
+        body = {
+            'enrollments_info': [
+                {
+                    'user_id': user.id,
+                    'course_run_key': course_id,
+                    'license_uuid': '5a88bdcade7c4ecb838f8111b68e18ac'
+                },
+            ]
+        }
+        def enroll():
+            self.client.post(
+                settings.TEST_SERVER + reverse(
+                    'enterprise-customer-enroll-learners-in-courses', (enterprise_customer.uuid,)
+                ),
+                data=json.dumps(body),
+                content_type='application/json',
+            )
+
+        enroll()
+        mock_cea.objects.update_or_create.assert_not_called()
+
+        enterprise_customer.allow_enrollment_in_invite_only_courses = True
+        enterprise_customer.save()
+
+        enroll()
+        mock_cea.objects.update_or_create.assert_called_with(
+            course_id=course_id,
+            email=user.email
+        )
+
+    @mock.patch('enterprise.api.v1.views.enterprise_customer.get_course_details_from_course_keys')
     @mock.patch('enterprise.api.v1.views.enterprise_customer.enroll_subsidy_users_in_courses')
     @mock.patch('enterprise.api.v1.views.enterprise_customer.get_best_mode_from_course_key')
-    def test_enroll_learners_in_courses_partial_failure(self, mock_get_course_mode, mock_enroll_user):
+    def test_enroll_learners_in_courses_partial_failure(
+        self,
+        mock_get_course_mode,
+        mock_enroll_user,
+        mock_get_course_details,
+    ):
         """
         Tests that bulk users bulk enrollment endpoint properly handles partial failures.
         """
+        mock_get_course_details.return_value.__getitem__.return_value.invitation_only = True
+
         ent_customer = factories.EnterpriseCustomerFactory(
             uuid=FAKE_UUIDS[0],
             name="test_enterprise"

--- a/tests/test_enterprise/test_utils.py
+++ b/tests/test_enterprise/test_utils.py
@@ -539,10 +539,9 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(len(truncated_string), MAX_ALLOWED_TEXT_LENGTH)
 
     @ddt.data(True, False)
-    @mock.patch("enterprise.utils.CourseEnrollmentAllowed")
-    def test_ensure_course_enrollment_is_allowed(self, invite_only, mock_cea):
+    def test_ensure_course_enrollment_is_allowed(self, invite_only):
         """
-        Test that the CourseEnrollmentAllowed is created only for the "invite_only" courses.
+        Test that the enrollment allow endpoint is called for the "invite_only" courses.
         """
         self.create_user()
         mock_enrollment_api = mock.Mock()
@@ -551,9 +550,9 @@ class TestUtils(unittest.TestCase):
         ensure_course_enrollment_is_allowed("test-course-id", self.user.email, mock_enrollment_api)
 
         if invite_only:
-            mock_cea.objects.update_or_create.assert_called_with(
-                course_id="test-course-id",
-                email=self.user.email
+            mock_enrollment_api.allow_enrollment.assert_called_with(
+                self.user.email,
+                "test-course-id",
             )
         else:
-            mock_cea.objects.update_or_create.assert_not_called()
+            mock_enrollment_api.allow_enrollment.assert_not_called()

--- a/tests/test_enterprise/views/test_course_enrollment_view.py
+++ b/tests/test_enterprise/views/test_course_enrollment_view.py
@@ -1623,10 +1623,8 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
     @mock.patch('enterprise.views.EnrollmentApiClient')
     @mock.patch('enterprise.views.get_data_sharing_consent')
     @mock.patch('enterprise.utils.Registry')
-    @mock.patch('enterprise.utils.CourseEnrollmentAllowed')
     def test_post_course_specific_enrollment_view_invite_only_courses(
             self,
-            mock_cea,
             registry_mock,
             get_data_sharing_consent_mock,
             enrollment_api_client_mock,
@@ -1664,9 +1662,9 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
             }
         )
 
-        mock_cea.objects.update_or_create.assert_called_with(
-            course_id=course_id,
-            email=self.user.email
+        enrollment_api_client_mock.return_value.allow_enrollment.assert_called_with(
+            self.user.email,
+            course_id,
         )
         assert response.status_code == 302
 


### PR DESCRIPTION
## Description

This fix allows enterprise learners to enroll into invite-only enterprise courses using the `frontend-app-learner-portal-enterprise` MFE.

This issue is easy to reproduce. Let's imagine we have an enterprise customer, with one invitation-only course in its catalog, enough funds and one linked leaner. The learner will see the following if visit the portal:
![image](https://github.com/open-craft/edx-enterprise/assets/18251194/3a5171f6-38f8-4e82-b168-05a52a3e3f0f)
Clicking `Enroll` will result in some error:
![image](https://github.com/open-craft/edx-enterprise/assets/18251194/37fe5206-0065-4b7a-9374-ca8e509dcca1)

Let's follow the request to understand what's causing it. First, frontend is sending a POST request to `http://localhost:18270/api/v1/policy-redemption/<per_learner_spend_credit_access_policy_uuid>/redeem/` URL with a body like this:
```json
{
  "lms_user_id": 20026,
  "content_key": "course-v1:PSY+PSY+PSY",
  "metadata": {}
}
```
Then, [this endpoint](https://github.com/openedx/enterprise-access/blob/9b1152c7f92a31143f0d561291306f54020530f4/enterprise_access/apps/api/v1/views/subsidy_access_policy.py#L289) is failing because of inability to create a subsidy transaction:
```python
2024-03-01 11:40:15,499 ERROR 23 [enterprise_access.apps.api.v1.views.subsidy_access_policy] [user 4] [ip 172.19.0.1] [request_id None] subsidy_access_policy.py:554 - HTTPError occurred in Subsidy API request. when creating transaction in subsidy API
Traceback (most recent call last):
  File "/edx/app/enterprise-access/enterprise_access/apps/subsidy_access_policy/models.py", line 791, in redeem
    return self.subsidy_client.create_subsidy_transaction(**creation_payload)
  File "/edx/venvs/enterprise-access/lib/python3.8/site-packages/edx_enterprise_subsidy_client/client.py", line 336, in create_subsidy_transaction
    response.raise_for_status()
  File "/edx/venvs/enterprise-access/lib/python3.8/site-packages/requests/models.py", line 1021, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 422 Client Error: Unprocessable Entity for url: http://enterprise-subsidy.app:18280/api/v2/subsidies/d3a489ae-f94e-42d6-af5a-bcb895bb511d/admin/transactions/

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/edx/app/enterprise-access/enterprise_access/apps/api/v1/views/subsidy_access_policy.py", line 537, in redeem
    redemption_result = policy.redeem(lms_user_id, content_key, existing_transactions, metadata)
  File "/edx/app/enterprise-access/enterprise_access/apps/subsidy_access_policy/models.py", line 793, in redeem
    raise SubsidyAPIHTTPError('HTTPError occurred in Subsidy API request.') from exc
enterprise_access.apps.subsidy_access_policy.exceptions.SubsidyAPIHTTPError: HTTPError occurred in Subsidy API request.
```

`enterprise-subsidy` service, in turn, is failing to create a transaction because LMS is failing to create an enrollment:

```python
2024-03-01 11:40:15,496 ERROR 9 [enterprise_subsidy.apps.subsidy.models] [user 2] [ip 172.19.0.35] [request_id None] models.py:478 - <Subsidy uuid=d3a489ae-f94e-42d6-af5a-bcb895bb511d, title=Test subsidy> cannot redeem course-v1:PSY+PSY+PSY with price 10000 for user 20026 in policy dd99c210-5c61-4c89-a3d6-c3dad09e5cc1. HTTPError during enrollment.
Traceback (most recent call last):
  File "/edx/app/enterprise-subsidy/enterprise_subsidy/apps/subsidy/models.py", line 463, in redeem
    transaction = self._create_redemption(
  File "/edx/app/enterprise-subsidy/enterprise_subsidy/apps/subsidy/models.py", line 586, in _create_redemption
    raise exc
  File "/edx/app/enterprise-subsidy/enterprise_subsidy/apps/subsidy/models.py", line 576, in _create_redemption
    enterprise_fulfillment_uuid = self.enterprise_client.enroll(lms_user_id, content_key, ledger_transaction)
  File "/edx/app/enterprise-subsidy/enterprise_subsidy/apps/api_client/enterprise.py", line 111, in enroll
    response = self.bulk_enroll_enterprise_learners(customer_uuid, enrollments_info)
  File "/edx/app/enterprise-subsidy/enterprise_subsidy/apps/api_client/enterprise.py", line 163, in bulk_enroll_enterprise_learners
    raise exc
  File "/edx/app/enterprise-subsidy/enterprise_subsidy/apps/api_client/enterprise.py", line 156, in bulk_enroll_enterprise_learners
    response.raise_for_status()
  File "/edx/venvs/enterprise-subsidy/lib/python3.8/site-packages/requests/models.py", line 1021, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 409 Client Error: Conflict for url: http://edx.devstack.lms:18000/enterprise/api/v1/enterprise-customer/55adc9d9-12de-4d0a-95c5-e01d0998aab8/enroll_learners_in_courses/
```

And LMS is failing to create an enrollment because `edx-enterprise`'s `enroll_learners_in_courses` is failing: 

```python
2024-03-01 11:40:15,472 ERROR 1670 [enterprise.utils] [user 20024] [ip 172.19.0.27] utils.py:1850 - Failed to enroll user 20026 in course course-v1:PSY+PSY+PSY
Traceback (most recent call last):
  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/enrollments/data.py", line 151, in create_course_enrollment
    enrollment = CourseEnrollment.enroll(
  File "/edx/app/edxapp/edx-platform/common/djangoapps/student/models/course_enrollment.py", line 690, in enroll
    raise EnrollmentClosedError
common.djangoapps.student.models.course_enrollment.EnrollmentClosedError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/edx/src/edx-enterprise/enterprise/utils.py", line 1840, in customer_admin_enroll_user_with_status
    new_enrollment = lms_update_or_create_enrollment(
  File "/edx/app/edxapp/edx-platform/openedx/features/enterprise_support/enrollments/utils.py", line 138, in lms_update_or_create_enrollment
    raise error
  File "/edx/app/edxapp/edx-platform/openedx/features/enterprise_support/enrollments/utils.py", line 101, in lms_update_or_create_enrollment
    response = enrollment_api.add_enrollment(
  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/enrollments/api.py", line 265, in add_enrollment
    enrollment = _data_api().create_course_enrollment(
  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/enrollments/data.py", line 158, in create_course_enrollment
    raise CourseEnrollmentClosedError(str(err))  # lint-amnesty, pylint: disable=raise-missing-from
openedx.core.djangoapps.enrollments.errors.CourseEnrollmentClosedError
2024-03-01 11:40:15,475 WARNING 1670 [enterprise.utils] [user 20024] [ip 172.19.0.27] utils.py:1894 - Failed to enroll user 20026 in course course-v1:PSY+PSY+PSY
[01/Mar/2024 11:40:15] "POST /enterprise/api/v1/enterprise-customer/55adc9d9-12de-4d0a-95c5-e01d0998aab8/enroll_learners_in_courses/ HTTP/1.1" 409 127
```

Unlike `CourseEnrollmentView`, this endpoint doesn't create `CourseEnrollmentAllowed` object automatically if an enterprise customer has `allow_enrollment_in_invite_only_courses` set to `True`. In this PR we fix exactly this.

## Testing

Configuring devstack to test this is a bit tedious.

First, get a working enterprise setup like described in the testing steps section of https://github.com/openedx/frontend-app-learner-portal-enterprise/pull/887, but with some differences:
- Skip adding `ENTERPRISE_ALGOLIA_SEARCH_API_KEY` to `devstack.py`.
- Use `0x29a/bb8626/enroll-enterprise-learners-in-invite-only-courses` branch for `edx-enterprise` repo.
- Use upstream master branch for `frontend-app-learner-portal-enterprise`.
- For `Installing frontend-app-learner-portal-enterprise` section, run also `export ALGOLIA_SEARCH_API_KEY=<your_search_api_key>`. 
- Skip `Enrolling users` step.

Then you have to make `Enroll` button work, which requires three additional services:

```bash
cd $DEVSTACK_WORKSPACE
git clone git@github.com:openedx/enterprise-subsidy.git
cd enterprise-subsidy
make dev.up.build-no-cache
bash provision-enterprise-subsidy.sh
cd $DEVSTACK_WORKSPACE
git clone git@github.com:openedx/license-manager.git
cd license-manager
make docker_build
make dev.provision
make dev.up
cd $DEVSTACK_WORKSPACE
git clone git@github.com:openedx/enterprise-access.git
cd enterprise-access
make docker_build
make dev.provision
make dev.up
```

Also you need to create some missing role assignments, so these services can work together:
1. Assign `enterprise_access_worker@example.com` to `enterprise_subsidy_admin` role here: http://localhost:18280/admin/subsidy/enterprisesubsidyroleassignment/
2. Assign `enterprise-subsidy_worker@example.com` and `enterprise_access_worker@example.com` to `enterprise_catalog_admin` role here: http://localhost:18160/admin/catalog/enterprisecatalogroleassignment/

Finally, in this context, some course is enroll-able only if it has price and if organization that own this course has a non-zero balance to subsidize learning. That's why you'll need to do the following:
1. Add a ledger here: http://localhost:18280/admin/openedx_ledger/ledger/add/.
2. Add a subsidy here: http://localhost:18280/admin/subsidy/subsidy/add. Be sure to note an enterprise customer UUID you use here.
3. Add a policy here: http://localhost:18270/admin/subsidy_access_policy/perlearnerspendcreditaccesspolicy/add/. Be sure to use a catalog UUID linked to a customer you set previously and set the spending limit to 1000000 cents.
4. Add an adjustment here: http://localhost:18280/admin/openedx_ledger/adjustment/, specify `$10,000,000.00` amount. After this, verify that the ledger's balance is 10 mil $.
5. Choose some course in the catalog of the previously chosen enterprise customer, find it here: http://localhost:18160/admin/catalog/contentmetadata/, and correct both course and course run to have `first_enrollable_paid_seat_price` == `100`.

Now you can register some leaner, link it to the previously chosen enterprise customer in `http://localhost:18000/admin/enterprise/enterprisecustomer/<enterprise_customer_uuid>/manage_learners`, and trying to enroll via the portal. It should fail unless `Allow enrollment in invite only courses` checkbox on `http://localhost:18000/admin/enterprise/enterprisecustomer/<enterprise_customer_uuid>/change/` page is set.

[Private ref](https://tasks.opencraft.com/browse/BB-8626)