### PR TITLE
fix: create CEA object when enrolling using a license flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [master]
   pull_request:
-    branches: [master]
 
 concurrency:
   group: ci-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/mysql8-migrations.yml
+++ b/.github/workflows/mysql8-migrations.yml
@@ -56,7 +56,7 @@ jobs:
         pip uninstall -y mysqlclient
         pip install --no-binary mysqlclient mysqlclient
         pip uninstall -y xmlsec
-        pip install --no-binary xmlsec xmlsec
+        pip install --no-binary xmlsec xmlsec==1.3.13
         pip install backports.zoneinfo
     - name: Initiate Services
       run: |

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -2407,19 +2407,14 @@ def truncate_string(string, max_length=MAX_ALLOWED_TEXT_LENGTH):
 
 def ensure_course_enrollment_is_allowed(course_id, email, enrollment_api_client):
     """
-    Create a CourseEnrollmentAllowed object for invitation-only courses.
+    Calls the enrollment API to create a CourseEnrollmentAllowed object for
+    invitation-only courses.
 
     Arguments:
         course_id (str): ID of the course to allow enrollment
         email (str): email of the user whose enrollment should be allowed
         enrollment_api_client (:class:`enterprise.api_client.lms.EnrollmentApiClient`): Enrollment API Client
     """
-    if not CourseEnrollmentAllowed:
-        raise NotConnectedToOpenEdX()
-
     course_details = enrollment_api_client.get_course_details(course_id)
     if course_details["invite_only"]:
-        CourseEnrollmentAllowed.objects.update_or_create(
-            course_id=course_id,
-            email=email,
-        )
+        enrollment_api_client.allow_enrollment(email, course_id)

--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -683,6 +683,15 @@ class GrantDataSharingPermissions(View):
                         existing_enrollment.get('mode') == constants.CourseModes.AUDIT or
                         existing_enrollment.get('is_active') is False
                 ):
+                    if enterprise_customer.allow_enrollment_in_invite_only_courses:
+                        ensure_course_enrollment_is_allowed(course_id, request.user.email, enrollment_api_client)
+                        LOGGER.info(
+                            'User {user} is allowed to enroll in Course {course_id}.'.format(
+                                user=request.user.username,
+                                course_id=course_id
+                            )
+                        )
+
                     course_mode = get_best_mode_from_course_key(course_id)
                     LOGGER.info(
                         'Retrieved Course Mode: {course_modes} for Course {course_id}'.format(

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -4512,7 +4512,6 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
         mock_update_or_create_enrollment.return_value = True
         mock_get_course_details.return_value.__getitem__.return_value.invitation_only = False
 
-
         user_one = factories.UserFactory(is_active=True)
         user_two = factories.UserFactory(is_active=True)
 
@@ -5001,6 +5000,7 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
                 },
             ]
         }
+
         def enroll():
             self.client.post(
                 settings.TEST_SERVER + reverse(

--- a/tests/test_enterprise/test_utils.py
+++ b/tests/test_enterprise/test_utils.py
@@ -539,10 +539,9 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(len(truncated_string), MAX_ALLOWED_TEXT_LENGTH)
 
     @ddt.data(True, False)
-    @mock.patch("enterprise.utils.CourseEnrollmentAllowed")
-    def test_ensure_course_enrollment_is_allowed(self, invite_only, mock_cea):
+    def test_ensure_course_enrollment_is_allowed(self, invite_only):
         """
-        Test that the CourseEnrollmentAllowed is created only for the "invite_only" courses.
+        Test that the enrollment allow endpoint is called for the "invite_only" courses.
         """
         self.create_user()
         mock_enrollment_api = mock.Mock()
@@ -551,9 +550,9 @@ class TestUtils(unittest.TestCase):
         ensure_course_enrollment_is_allowed("test-course-id", self.user.email, mock_enrollment_api)
 
         if invite_only:
-            mock_cea.objects.update_or_create.assert_called_with(
+            mock_enrollment_api.return_value.allow_enrollment.assert_called_with(
+                email=self.user.email,
                 course_id="test-course-id",
-                email=self.user.email
             )
         else:
-            mock_cea.objects.update_or_create.assert_not_called()
+            mock_enrollment_api.return_value.allow_enrollment.assert_not_called()

--- a/tests/test_enterprise/test_utils.py
+++ b/tests/test_enterprise/test_utils.py
@@ -550,9 +550,9 @@ class TestUtils(unittest.TestCase):
         ensure_course_enrollment_is_allowed("test-course-id", self.user.email, mock_enrollment_api)
 
         if invite_only:
-            mock_enrollment_api.return_value.allow_enrollment.assert_called_with(
-                email=self.user.email,
-                course_id="test-course-id",
+            mock_enrollment_api.allow_enrollment.assert_called_with(
+                self.user.email,
+                "test-course-id",
             )
         else:
-            mock_enrollment_api.return_value.allow_enrollment.assert_not_called()
+            mock_enrollment_api.allow_enrollment.assert_not_called()

--- a/tests/test_enterprise/views/test_course_enrollment_view.py
+++ b/tests/test_enterprise/views/test_course_enrollment_view.py
@@ -1623,10 +1623,8 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
     @mock.patch('enterprise.views.EnrollmentApiClient')
     @mock.patch('enterprise.views.get_data_sharing_consent')
     @mock.patch('enterprise.utils.Registry')
-    @mock.patch('enterprise.utils.CourseEnrollmentAllowed')
     def test_post_course_specific_enrollment_view_invite_only_courses(
             self,
-            mock_cea,
             registry_mock,
             get_data_sharing_consent_mock,
             enrollment_api_client_mock,
@@ -1664,9 +1662,9 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
             }
         )
 
-        mock_cea.objects.update_or_create.assert_called_with(
+        enrollment_api_client_mock.return_value.allow_enrollment.assert_called_with(
+            email=self.user.email,
             course_id=course_id,
-            email=self.user.email
         )
         assert response.status_code == 302
 

--- a/tests/test_enterprise/views/test_course_enrollment_view.py
+++ b/tests/test_enterprise/views/test_course_enrollment_view.py
@@ -1663,8 +1663,8 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
         )
 
         enrollment_api_client_mock.return_value.allow_enrollment.assert_called_with(
-            email=self.user.email,
-            course_id=course_id,
+            self.user.email,
+            course_id,
         )
         assert response.status_code == 302
 


### PR DESCRIPTION
This is a port of https://github.com/open-craft/edx-enterprise/pull/19.