### PR TITLE
fix: create CEA object when enrolling using a license flow [PALM]

### DIFF
--- a/.github/workflows/mysql8-migrations.yml
+++ b/.github/workflows/mysql8-migrations.yml
@@ -60,7 +60,7 @@ jobs:
         pip uninstall -y mysqlclient
         pip install --no-binary mysqlclient mysqlclient
         pip uninstall -y xmlsec
-        pip install --no-binary xmlsec xmlsec
+        pip install --no-binary xmlsec xmlsec==1.3.13
     - name: Initiate Services
       run: |
         sudo /etc/init.d/mysql start

--- a/enterprise/api_client/lms.py
+++ b/enterprise/api_client/lms.py
@@ -6,6 +6,7 @@ import logging
 import time
 from urllib.parse import urljoin
 
+import requests
 from opaque_keys.edx.keys import CourseKey
 from requests.exceptions import (  # pylint: disable=redefined-builtin
     ConnectionError,
@@ -282,6 +283,34 @@ class EnrollmentApiClient(BackendServiceAPIClient):
         api_url = self.get_api_url("enrollment")
         response = self.client.get(api_url, params={"user": username})
         response.raise_for_status()
+        return response.json()
+
+    def allow_enrollment(self, email, course_id, auto_enroll=False):
+        """
+        Call the enrollment API to allow enrollment for the given email and course_id.
+
+        Args:
+            email (str): The email address of the user to be allowed to enroll in the course.
+            course_id (str): The string value of the course's unique identifier.
+            auto_enroll (bool): Whether to auto-enroll the user in the course upon registration / activation.
+
+        Returns:
+            dict: A dictionary containing details of the created CourseEnrollmentAllowed object.
+
+        """
+        api_url = self.get_api_url("enrollment_allowed")
+        response = self.client.post(
+            f"{api_url}/",
+            json={
+                'email': email,
+                'course_id': course_id,
+                'auto_enroll': auto_enroll,
+            }
+        )
+        if response.status_code == requests.codes.conflict:
+            LOGGER.info(response.json()["message"])
+        else:
+            response.raise_for_status()
         return response.json()
 
 

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -2339,19 +2339,14 @@ def hide_price_when_zero(enterprise_customer, course_modes):
 
 def ensure_course_enrollment_is_allowed(course_id, email, enrollment_api_client):
     """
-    Create a CourseEnrollmentAllowed object for invitation-only courses.
+    Calls the enrollment API to create a CourseEnrollmentAllowed object for
+    invitation-only courses.
 
     Arguments:
         course_id (str): ID of the course to allow enrollment
         email (str): email of the user whose enrollment should be allowed
         enrollment_api_client (:class:`enterprise.api_client.lms.EnrollmentApiClient`): Enrollment API Client
     """
-    if not CourseEnrollmentAllowed:
-        raise NotConnectedToOpenEdX()
-
     course_details = enrollment_api_client.get_course_details(course_id)
     if course_details["invite_only"]:
-        CourseEnrollmentAllowed.objects.update_or_create(
-            course_id=course_id,
-            email=email,
-        )
+        enrollment_api_client.allow_enrollment(email, course_id)

--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -684,6 +684,15 @@ class GrantDataSharingPermissions(View):
                         existing_enrollment.get('mode') == constants.CourseModes.AUDIT or
                         existing_enrollment.get('is_active') is False
                 ):
+                    if enterprise_customer.allow_enrollment_in_invite_only_courses:
+                        ensure_course_enrollment_is_allowed(course_id, request.user.email, enrollment_api_client)
+                        LOGGER.info(
+                            'User {user} is allowed to enroll in Course {course_id}.'.format(
+                                user=request.user.username,
+                                course_id=course_id
+                            )
+                        )
+
                     course_mode = get_best_mode_from_course_key(course_id)
                     LOGGER.info(
                         'Retrieved Course Mode: {course_modes} for Course {course_id}'.format(

--- a/tests/test_enterprise/test_utils.py
+++ b/tests/test_enterprise/test_utils.py
@@ -534,9 +534,9 @@ class TestUtils(unittest.TestCase):
         ensure_course_enrollment_is_allowed("test-course-id", self.user.email, mock_enrollment_api)
 
         if invite_only:
-            mock_enrollment_api.return_value.allow_enrollment.assert_called_with(
-                email=self.user.email,
-                course_id="test-course-id",
+            mock_enrollment_api.allow_enrollment.assert_called_with(
+                self.user.email,
+                "test-course-id",
             )
         else:
-            mock_enrollment_api.return_value.allow_enrollment.assert_not_called()
+            mock_enrollment_api.allow_enrollment.assert_not_called()

--- a/tests/test_enterprise/test_utils.py
+++ b/tests/test_enterprise/test_utils.py
@@ -523,10 +523,9 @@ class TestUtils(unittest.TestCase):
             self.assertEqual(non_zero_modes, processed_non_zero_modes)
 
     @ddt.data(True, False)
-    @mock.patch("enterprise.utils.CourseEnrollmentAllowed")
-    def test_ensure_course_enrollment_is_allowed(self, invite_only, mock_cea):
+    def test_ensure_course_enrollment_is_allowed(self, invite_only):
         """
-        Test that the CourseEnrollmentAllowed is created only for the "invite_only" courses.
+        Test that the enrollment allow endpoint is called for the "invite_only" courses.
         """
         self.create_user()
         mock_enrollment_api = mock.Mock()
@@ -535,9 +534,9 @@ class TestUtils(unittest.TestCase):
         ensure_course_enrollment_is_allowed("test-course-id", self.user.email, mock_enrollment_api)
 
         if invite_only:
-            mock_cea.objects.update_or_create.assert_called_with(
+            mock_enrollment_api.return_value.allow_enrollment.assert_called_with(
+                email=self.user.email,
                 course_id="test-course-id",
-                email=self.user.email
             )
         else:
-            mock_cea.objects.update_or_create.assert_not_called()
+            mock_enrollment_api.return_value.allow_enrollment.assert_not_called()

--- a/tests/test_enterprise/views/test_course_enrollment_view.py
+++ b/tests/test_enterprise/views/test_course_enrollment_view.py
@@ -1623,10 +1623,8 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
     @mock.patch('enterprise.views.EnrollmentApiClient')
     @mock.patch('enterprise.views.get_data_sharing_consent')
     @mock.patch('enterprise.utils.Registry')
-    @mock.patch('enterprise.utils.CourseEnrollmentAllowed')
     def test_post_course_specific_enrollment_view_invite_only_courses(
             self,
-            mock_cea,
             registry_mock,
             get_data_sharing_consent_mock,
             enrollment_api_client_mock,
@@ -1664,9 +1662,9 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
             }
         )
 
-        mock_cea.objects.update_or_create.assert_called_with(
+        enrollment_api_client_mock.return_value.allow_enrollment.assert_called_with(
+            email=self.user.email,
             course_id=course_id,
-            email=self.user.email
         )
         assert response.status_code == 302
 

--- a/tests/test_enterprise/views/test_course_enrollment_view.py
+++ b/tests/test_enterprise/views/test_course_enrollment_view.py
@@ -1663,8 +1663,8 @@ class TestCourseEnrollmentView(EmbargoAPIMixin, EnterpriseViewMixin, MessagesMix
         )
 
         enrollment_api_client_mock.return_value.allow_enrollment.assert_called_with(
-            email=self.user.email,
-            course_id=course_id,
+            self.user.email,
+            course_id,
         )
         assert response.status_code == 302
 


### PR DESCRIPTION
## Description

This fix is similar to https://github.com/open-craft/edx-enterprise/pull/14, but it's for license-based enrollment flow.

## Testing steps

Follow testing steps from https://github.com/open-craft/edx-enterprise/pull/14 up until `Add a ledger here` step. Be sure to use https://github.com/open-craft/edx-platform/pull/656 branch for `edx-platform` during the devstack setup. Then:
1. Register some test user.
2. Note a UUID of some enterprise customer and its enterprise catalog.
3. Add an agreement here: http://localhost:18170/admin/subscriptions/customeragreement/ using UUIDs from №2.
4. Add a subscription here: http://localhost:18170/admin/subscriptions/subscriptionplan/ using UUIDs from №2. You can specify these details:
    ```
    Is active: check.
    Number of Licenses: 200.
    Salesforce opportunity line item: `00kNFJHRVSD683NDI8`.
    Product: `B2B Paid`.
    Should auto apply licenses: `Yes`.
    Reason for change: `New Subscription`.
    ```
5. The previous step should create 200 licenses here: http://localhost:18170/admin/subscriptions/license/. Choose one of them, set it to be `Activated` and set LMS user ID to the ID of the user you created in №1.
6. You may also need to add an assignment here: http://localhost:18160/admin/catalog/enterprisecatalogroleassignment/
    ```
    email: license_manager_worker@example.com
    role: enterprise_catalog_admin
    applies_to_all_contexts: true
    ```
7. Now add the test user to the chosen enterprise customer with an invitation-only course in its catalog and try enrolling this user to this course via the enterprise learner portal MFE.